### PR TITLE
Sync scroll in INSERT mode too

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -122,10 +122,10 @@ function! s:open_window() abort
     augroup MinimapAutoCmds
         autocmd!
         autocmd WinEnter <buffer> if winnr('$') == 1|q|endif
-        autocmd BufWritePost            * call s:refresh_content()
-        autocmd BufEnter                * call s:buffer_enter_handler()
-        autocmd FocusGained,CursorMoved * call s:cursor_move_handler()
-        autocmd WinEnter                * call s:win_enter_handler()
+        autocmd BufWritePost                         * call s:refresh_content()
+        autocmd BufEnter                             * call s:buffer_enter_handler()
+        autocmd FocusGained,CursorMoved,CursorMovedI * call s:cursor_move_handler()
+        autocmd WinEnter                             * call s:win_enter_handler()
     augroup END
 
     let &cpoptions = cpoptions_save


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

This allows the minimap to sync scroll position when the buffer is in INSERT mode. As discussed in #10 

## Type of change

- [x] New feature

## Test environment

- OS
    - [x] Linux
- Vim
    - [x] Neovim: <Version>

