### PR TITLE
fix: disable cursorline for minimap window (#8)

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -109,12 +109,13 @@ function! s:open_window() abort
     setlocal nospell
     setlocal nowrap
     setlocal nonumber
-    silent! setlocal norelativenumber
     setlocal nofoldenable
     setlocal foldcolumn=0
     setlocal foldmethod&
     setlocal foldexpr&
+    setlocal nocursorline
     silent! setlocal signcolumn=no
+    silent! setlocal norelativenumber
 
     let cpoptions_save = &cpoptions
     set cpoptions&vim


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

By default, the newly opened window will inherit the properties of the original window. `cursorline` should make no sense to minimap so we disable it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CICD related improvement

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: <Version>
    - [x] Vim: <Version>
