### PR TITLE
fix: coerce Windows to use cmd.exe for shell script

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -171,6 +171,12 @@ function! s:process_buffer(mmwinnr, bufnr, fname, ftype) abort
     let hscale = string(2.0 * g:minimap_width / min([winwidth('%'), 120]))
     let vscale = string(4.0 * winheight(winid) / line('$'))
 
+    " Powershell doesn't work, so we need to use cmd.exe for Windows.
+    if has('win32') && &shell[-7:-1] !=? 'cmd.exe'
+        let usershell = &shell
+        let &shell = 'cmd.exe'
+    endif
+
     if has('nvim')
         let minimap_cmd = 'w !'.s:minimap_gen.' '.hscale.' '.vscale.' '.g:minimap_width
         " echom minimap_cmd
@@ -181,6 +187,10 @@ function! s:process_buffer(mmwinnr, bufnr, fname, ftype) abort
         let minimap_output = system(minimap_cmd)
     endif
 
+    " Recover the user's selected shell.
+    if exists('usershell')
+        let &shell = usershell
+    endif
 
     if v:shell_error
         " print error message if file exists


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [X] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [X] I have searched through the existing issues or pull requests
- [X] I have performed a self-review of my code and commented hard-to-understand areas
- [X] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

I noticed that Powershell would not work with minimap.vim at all, which is problematic if the user has `set shell=pwsh` in their init.vim.  I added some code to always execute the minimap_generator script in cmd.exe for Windows users.

Consequently, if one sets their shell to bash, wsl, pwsh, powershell, etc. the plugin will always run under cmd.exe.  This ensures that the plugin works no matter what shell the user has set.

This should not break minimap for other OS's as the code only executes for Windows machines.  However, I can't say the same for Vim users (as opposed to Neovim): I failed to get minimap to work on my hastily set-up Windows 8.1 - Vim 8.2 environment, with or without the change.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CICD related improvement

## Test environment

- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [X] Windows
    - [ ] Others:
- Vim
    - [X] Neovim: 0.5.0
    - [ ] Vim: <Version>
