### PR TITLE
Not break the default register when refreshing

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -229,9 +229,9 @@ function! s:render_content(mmwinnr, bufnr, fname, ftype) abort
     silent 1,$delete _
     silent put =cache.content
     if has('nvim')
-        silent 1,3delete
+        silent 1,3delete _
     else
-        silent 1delete
+        silent 1delete _
     endif
 
     setlocal nomodifiable


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

fixed minimap breaks the default register when refreshing.

#23 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CICD related improvement

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2
