### PR TITLE
Force default shell

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -185,7 +185,7 @@ function! s:process_buffer(mmwinnr, bufnr, fname, ftype) abort
     let hscale = string(2.0 * g:minimap_width / min([winwidth('%'), 120]))
     let vscale = string(4.0 * winheight(winid) / line('$'))
 
-    " Users that have set up shells may interfere with program execution.
+    " Users that have custom shells may face problems.
     let usershell = &shell
     let &shell = s:default_shell
 

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -43,8 +43,10 @@ endfunction
 let s:bin_dir = expand('<sfile>:p:h:h:h').'/bin/'
 if has('win32')
     let s:minimap_gen = s:bin_dir.'minimap_generator.bat'
+    let s:default_shell = 'cmd.exe'
 else
     let s:minimap_gen = s:bin_dir.'minimap_generator.sh'
+    let s:default = 'bash'
 endif
 let s:minimap_cache = {}
 
@@ -183,11 +185,9 @@ function! s:process_buffer(mmwinnr, bufnr, fname, ftype) abort
     let hscale = string(2.0 * g:minimap_width / min([winwidth('%'), 120]))
     let vscale = string(4.0 * winheight(winid) / line('$'))
 
-    " Powershell doesn't work, so we need to use cmd.exe for Windows.
-    if has('win32') && &shell[-7:-1] !=? 'cmd.exe'
-        let usershell = &shell
-        let &shell = 'cmd.exe'
-    endif
+    " Users that have set up shells may interfere with program execution.
+    let usershell = &shell
+    let &shell = s:default_shell
 
     if has('nvim')
         let minimap_cmd = 'w !'.s:minimap_gen.' '.hscale.' '.vscale.' '.g:minimap_width
@@ -200,9 +200,7 @@ function! s:process_buffer(mmwinnr, bufnr, fname, ftype) abort
     endif
 
     " Recover the user's selected shell.
-    if exists('usershell')
-        let &shell = usershell
-    endif
+    let &shell = usershell
 
     if v:shell_error
         " print error message if file exists


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

On Linux, I use neofetch when I open fish.  My default shell is fish, so the minimap output ended up showing neofetch instead of the minimap.  I figured we might as well always use CMD/Bash, in the case that someone uses a shell that breaks out of the box.  These both are known to work and are universal.  (All Windows comes with CMD, and both Linux and Mac come with Bash.)

This was tested on Neovim 0.5 (Windows, Linux) and Vim 8.2 (Linux).  Again, I couldn't get minimap.vim to work on Windows with Vim 8.2 at all.  (I'll look into it some more, and submit an issue/PR.)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement of existing features
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2 (*with caveats:* only on Linux!)
