### PR TITLE
Update README and change buffer name

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ let g:minimap_width = 2
 Or use [scrollbar.nvim](https://github.com/Xuyuanp/scrollbar.nvim) instead if what you want
 is a pure scrollbar indicator.
 
+---
+### A jumble of characters show up instead of dots?
+
+Vim 8.2 uses the encoding 'latin1' by default, if it can't detect locale from the environment.  (You're probably on Windows.)
+Check that your encoding is set to 'utf-8' in your .vimrc file; the minimap will not correctly display otherwise.
+Unfortunately, encoding is not window-local!  It will change the encoding of all *shown* text to utf-8.
+
+
 ### 📦 Related Projects
 
 * [code-minimap](https://github.com/wfxr/code-minimap): A high performance code minimap render.

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -49,7 +49,7 @@ endif
 let s:minimap_cache = {}
 
 function! s:toggle_window() abort
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
     if mmwinnr != -1
         call s:close_window()
         return
@@ -60,7 +60,7 @@ endfunction
 
 function! s:close_window() abort
     silent! call matchdelete(g:minimap_cursorline_matchid)
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
     if mmwinnr == -1
         return
     endif
@@ -87,13 +87,13 @@ endfunction
 
 function! s:open_window() abort
     " If the minimap window is already open jump to it
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
     if mmwinnr != -1
         return
     endif
 
     let openpos = g:minimap_left ? 'topleft vertical ' : 'botright vertical '
-    execute 'silent! ' . openpos . g:minimap_width . 'split ' . 'MINIMAP'
+    execute 'silent! ' . openpos . g:minimap_width . 'split ' . '-MINIMAP-'
 
     " Buffer-local options
     setlocal filetype=minimap
@@ -154,7 +154,7 @@ function! s:refresh_content() abort
         return
     endif
 
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
 
     if mmwinnr == -1
         return
@@ -251,7 +251,7 @@ function! s:render_content(mmwinnr, bufnr, fname, ftype) abort
 endfunction
 
 function! s:source_move() abort
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
     if mmwinnr == -1
         return
     endif


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [X] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [X] I have searched through the existing issues or pull requests
- [X] I have performed a self-review of my code and commented hard-to-understand areas
- [X] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

These were my biggest problems with minimap in Vim 8.2 on Windows.  

- Vim set its locale to 'latin1' by default; I put a notice in the FAQ about changing your encoding to utf-8.  Without the encoding set to 'utf-8', only a jumble of latinate characters will display in the minimap window.  Instead of changing the code to set the encoding (unfortunately we can't set a window-local encoding), I decided to let people know in the FAQ, so as to placate users who deliberately needed 'latin1' encodings.

- If you want to use the minimap in a path that contains the substring 'minimap', it will fail to open.  Vim's version of `bufwinnr()` is case-insensitive, so it will consider the buffer that has a filepath with 'minimap' in it as the minimap's buffer, and thus refuse to open the minimap.  This change makes that less likely, unless you are deliberately trying to break the plugin by having '\<minimap\>' somewhere in the full path of your file.  However, this discrepancy in behavior between Vim 8.2 and Neovim is mainly a discussion between those projects.  (Neovim's approach benefits us, of course.)

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [X] Refactor
- [ ] Breaking change
- [X] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [X] Linux
    - [ ] Mac OS X
    - [X] Windows
    - [ ] Others:
- Vim
    - [X] Neovim: 0.5.0
    - [X] Vim: 8.2
