### PR TITLE
Make bufname less common

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -49,7 +49,7 @@ endif
 let s:minimap_cache = {}
 
 function! s:toggle_window() abort
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
     if mmwinnr != -1
         call s:close_window()
         return
@@ -60,7 +60,7 @@ endfunction
 
 function! s:close_window() abort
     silent! call matchdelete(g:minimap_cursorline_matchid)
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
     if mmwinnr == -1
         return
     endif
@@ -87,13 +87,13 @@ endfunction
 
 function! s:open_window() abort
     " If the minimap window is already open jump to it
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
     if mmwinnr != -1
         return
     endif
 
     let openpos = g:minimap_left ? 'topleft vertical ' : 'botright vertical '
-    execute 'silent! ' . openpos . g:minimap_width . 'split ' . 'MINIMAP'
+    execute 'silent! ' . openpos . g:minimap_width . 'split ' . '-MINIMAP-'
 
     " Buffer-local options
     setlocal filetype=minimap
@@ -154,7 +154,7 @@ function! s:refresh_content() abort
         return
     endif
 
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
 
     if mmwinnr == -1
         return
@@ -251,7 +251,7 @@ function! s:render_content(mmwinnr, bufnr, fname, ftype) abort
 endfunction
 
 function! s:source_move() abort
-    let mmwinnr = bufwinnr('MINIMAP')
+    let mmwinnr = bufwinnr('-MINIMAP-')
     if mmwinnr == -1
         return
     endif


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

Vim 8.2's version of `bufwinnr()` is case-insensitive (Neovim's is case-sensitive).   It will match if you have 'minimap' in the path to any of the files open in Vim, and thus not open the minimap, as it thinks it's already open.  It's not a *common* occurrence, but the plugin should at least be able to work in it's own directory!

I also tried '<>' and '||', but the former causes a delay when opening the minimap, and the latter breaks.  There may be a better character than '-' that is more unique.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2
