### PR TITLE
docs: add faq about latin1 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ hi MinimapCurrentLine ctermfg=Green guifg=#50FA7B guibg=#32302f
 let g:minimap_highlight = 'MinimapCurrentLine'
 ```
 
+---
+### Minimap shows up as a jumble of characters?
+
+Check that your encoding is set to `utf-8` and not `latin1` (for Vim users).
+Also, ensure that you're using a Unicode-compatible font that has Braille characters in it.
+
 ### 📦 Related Projects
 
 * [code-minimap](https://github.com/wfxr/code-minimap): A high performance code minimap render.

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -100,6 +100,13 @@ g:minimap_auto_start                                     *g:minimap_auto_start*
       let g:minimap_highlight = 'MinimapCurrentLine'
 
 
+|Q:|
+  Minimap shows up as a jumble of characters?
+
+|A:|
+  Check that your encoding is set to `utf-8` and not `latin1` (for Vim users), and check that you're using a font that is Unicode-compatible.
+
+
 LICENSE                                                       *minimap-license*
 =============================================================================
 


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

Using Vim 8.2 opens you to using a `latin1` encoding by default, which will not display Braille characters.  Updated FAQ to notify users (and also remark that they should need a Unicode font). 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2
