### PR TITLE
fix: Force default shell on all platforms

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -43,8 +43,10 @@ endfunction
 let s:bin_dir = expand('<sfile>:p:h:h:h').'/bin/'
 if has('win32')
     let s:minimap_gen = s:bin_dir.'minimap_generator.bat'
+    let s:default_shell = 'cmd.exe'
 else
     let s:minimap_gen = s:bin_dir.'minimap_generator.sh'
+    let s:default_shell = 'bash'
 endif
 let s:minimap_cache = {}
 
@@ -183,11 +185,9 @@ function! s:process_buffer(mmwinnr, bufnr, fname, ftype) abort
     let hscale = string(2.0 * g:minimap_width / min([winwidth('%'), 120]))
     let vscale = string(4.0 * winheight(winid) / line('$'))
 
-    " Powershell doesn't work, so we need to use cmd.exe for Windows.
-    if has('win32') && &shell[-7:-1] !=? 'cmd.exe'
-        let usershell = &shell
-        let &shell = 'cmd.exe'
-    endif
+    " Users that have custom shells may face problems.
+    let usershell = &shell
+    let &shell = s:default_shell
 
     if has('nvim')
         let minimap_cmd = 'w !'.s:minimap_gen.' '.hscale.' '.vscale.' '.g:minimap_width
@@ -200,9 +200,7 @@ function! s:process_buffer(mmwinnr, bufnr, fname, ftype) abort
     endif
 
     " Recover the user's selected shell.
-    if exists('usershell')
-        let &shell = usershell
-    endif
+    let &shell = usershell
 
     if v:shell_error
         " print error message if file exists

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -46,7 +46,7 @@ if has('win32')
     let s:default_shell = 'cmd.exe'
 else
     let s:minimap_gen = s:bin_dir.'minimap_generator.sh'
-    let s:default_shell = 'bash'
+    let s:default_shell = 'sh'
 endif
 let s:minimap_cache = {}
 


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

If a user has a custom shell set up, the shell might interfere with the output of the minimap. For example, neofetch and fish might display the ASCII arch in the minimap window. 

This change forces the plugin to use a universal shell such as CMD on Windows and Bash on Unix, and supersedes the earlier change forcing the plugin on Windows to use CMD.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2
