### PR TITLE
fix: trigger "Vim closing" autocmds on quit

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -85,6 +85,18 @@ function! s:close_window() abort
     endif
 endfunction
 
+function! s:close_window_last() abort
+    " We are on the last tab and the <MINIMAP> buffer is in the last window
+    let tabnum = tabpagenr()
+    if winnr('$') == 1
+        silent! call s:close_window()
+        if tabnum == tabpagenr('$') && tabnum == 1
+            doautocmd ExitPre,VimLeavePre,VimLeave 
+        endif
+        quit
+    endif
+endfunction
+
 function! s:open_window() abort
     " If the minimap window is already open jump to it
     let mmwinnr = bufwinnr('MINIMAP')
@@ -124,7 +136,7 @@ function! s:open_window() abort
 
     augroup MinimapAutoCmds
         autocmd!
-        autocmd WinEnter <buffer> if winnr('$') == 1|q|silent! call s:close_window()|endif
+        autocmd WinEnter                      <buffer> call s:close_window_last()
         autocmd BufWritePost                         * call s:refresh_content()
         autocmd BufEnter                             * call s:buffer_enter_handler()
         autocmd FocusGained,CursorMoved,CursorMovedI * call s:cursor_move_handler()


### PR DESCRIPTION


<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

In #12, we found that when the minimap window is open, quitting Vim altogether doesn't trigger the autocmds that should trigger on close, as if it was run with `noautocmd`.

This change manually triggers certain autocmds that were not triggered before.  It defines a function `s:close_window_last` that is called when the minimap buffer is entered.  If the minimap buffer is the last left, it calls the regular `s:close_window` and afterwards triggers the autocmds.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2
