### PR TITLE
fix: Update highlights correctly at all times

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -257,6 +257,32 @@ function! s:source_move() abort
     call s:highlight_line(winid, pos)
 endfunction
 
+" botline is broken and this works.  However, it's slow, so we call this function less.
+" Remove this function when `getwininfo().botline` is fixed.
+function! s:update_highlight() abort
+    let mmwinnr = bufwinnr('-MINIMAP-')
+    if mmwinnr == -1
+        return
+    endif
+
+    if winnr() == mmwinnr
+        return
+    endif
+
+    let winid = win_getid(mmwinnr)
+    let curr = line('.') - 1
+    let total = line('$')
+
+    let l:winview = winsaveview()
+    execute mmwinnr . 'wincmd w'
+    let mmheight = line('w$')
+    execute 'wincmd p'
+    call winrestview(l:winview)
+    
+    let pos = float2nr(1.0 * curr / total * mmheight) + 1
+    call s:highlight_line(winid, pos)
+endfunction
+
 function! s:highlight_line(winid, pos) abort
     silent! call matchdelete(g:minimap_cursorline_matchid, a:winid) " require vim 8.1.1084+ or neovim 0.5.0+
     call matchadd(g:minimap_highlight, '\%' . a:pos . 'l', 100, g:minimap_cursorline_matchid, { 'window': a:winid })

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -313,7 +313,7 @@ function! s:minimap_win_enter() abort
 endfunction
 
 function! s:source_win_enter() abort
-    call s:source_move()
+    call s:update_highlight()
 endfunction
 
 function! s:minimap_buffer_enter_handler() abort

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -149,6 +149,7 @@ function! s:open_window() abort
     let &cpoptions = cpoptions_save
 
     execute 'wincmd p'
+    call s:update_highlight()
 endfunction
 
 function! s:refresh_minimap(force) abort

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -130,7 +130,7 @@ function! s:open_window() abort
     augroup MinimapAutoCmds
         autocmd!
         autocmd WinEnter                      <buffer> call s:close_window_last()
-        autocmd BufWritePost,VimResized              * call s:refresh_minimap(1)
+        autocmd BufWritePost,VimResized              * call s:refresh_minimap(1) | call s:update_highlight()
         autocmd BufEnter                             * call s:buffer_enter_handler()
         autocmd FocusGained,CursorMoved,CursorMovedI * call s:cursor_move_handler()
         autocmd WinEnter                             * call s:win_enter_handler()

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -322,4 +322,5 @@ endfunction
 
 function! s:source_buffer_enter_handler() abort
     call s:refresh_minimap(0)
+    call s:update_highlight()
 endfunction


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

In #30 and #39 there is a slew of issues related to the broken function `getwininfo(...)[0].botline`.  The height of the window returned from this function is incorrect.

We can produce the correct behavior with the use of this code:

```vimL
execute mmwinnr . 'wincmd w'
let mmheight = line('w$')
execute 'wincmd p'
```

... however, it is slower and not fit for a CursorMoved event.  Therefore, the solution is to split `s:source_move()` into two parts, so that one is called during CursorMoved, and one is called on WinEnter/BufEnter/Opening/Closing/etc.  We make this split because `...botline` is quick and suited to being called often (and it works under CursorMoved), and `wincmd...` is slow but only needs to be called few times, to ensure correct behavior wherever `botline` breaks.

NOTE: As for #39, the specific fix to that issue is to call `s:source_move()` after refreshing the minimap; however, `s:source_move()` doesn't work right always because of botline, so we package it with the `s:update_highlight()` changes.

NOTE: In an attempt to edit a commit message, I accidentally merged the branch into itself, creating a bunch of clutter.  This explains the force push, which just removes the redundant commits.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2
