### PR TITLE
fix: removed autocmd FileType for popup compatib.

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -141,7 +141,7 @@ function! s:open_window() abort
                     \ if !s:ignored_filetypes() |
                     \ call s:refresh_minimap(1) |
                     \ call s:update_highlight()
-        autocmd BufEnter,FileType *
+        autocmd BufEnter *
                     \ if !s:ignored_filetypes() |
                     \ call s:buffer_enter_handler()
         autocmd FocusGained,CursorMoved,CursorMovedI *


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

As of yet, I don't see that having the autocmd FileType is necessary for this function.  It also causes issue #47. 

I tested it with vim-fugitive, NERDTree, and Startify.  Everything proceeded as intended with both Vim and Neovim.  I opened this as a pull request in case you know of a definite reason to keep the autocmd and take a different approach.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2
