### PR TITLE
feat: Add compatibility with tagbar plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ Plug 'wfxr/minimap.vim', {'do': ':!cargo install --locked code-minimap'}
 
 ### ⚙  Options
 
-| Flag                        | Default                    | Description                                   |
-|-----------------------------|----------------------------|-----------------------------------------------|
-| `g:minimap_auto_start`      | `0`                        | if set minimap will show at startup           |
-| `g:minimap_width`           | `10`                       | the width of the minimap window in characters |
-| `g:minimap_highlight`       | `Title`                    | the color group for current position          |
-| `g:minimap_base_highlight`  | `Normal`                   | the base color group for minimap              |
-| `g:minimap_block_filetypes` | `['fugitive', 'nerdtree']` | disable minimap for specific file types       |
-| `g:minimap_left`            | `0`                        | if set minimap window will append left        |
+| Flag                        | Default                               | Description                                   |
+|-----------------------------|---------------------------------------|-----------------------------------------------|
+| `g:minimap_auto_start`      | `0`                                   | if set minimap will show at startup           |
+| `g:minimap_width`           | `10`                                  | the width of the minimap window in characters |
+| `g:minimap_highlight`       | `Title`                               | the color group for current position          |
+| `g:minimap_base_highlight`  | `Normal`                              | the base color group for minimap              |
+| `g:minimap_block_filetypes` | `['fugitive', 'nerdtree', 'tagbar' ]` | disable minimap for specific file types       |
+| `g:minimap_left`            | `0`                                   | if set minimap window will append left        |
 
 ### 💬 F.A.Q
 

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -66,7 +66,7 @@ g:minimap_auto_start                                     *g:minimap_auto_start*
 g:minimap_block_filetypes                           *g:minimap_block_filetypes*
 
   Type: |Array|
-  Default: `['fugitive', 'nerdtree']`
+  Default: `['fugitive', 'nerdtree', 'tagbar']`
 
   Disable minimap for specific file types.
 

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -51,7 +51,7 @@ if !exists('g:minimap_cursorline_matchid')
 endif
 
 if !exists('g:minimap_block_filetypes')
-    let g:minimap_block_filetypes = ['fugitive', 'nerdtree']
+    let g:minimap_block_filetypes = ['fugitive', 'nerdtree', 'tagbar']
 endif
 
 if g:minimap_auto_start == 1


### PR DESCRIPTION
Adds out-of-box support for using in combination with Tagbar.

See https://github.com/preservim/tagbar/issues/700

----

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: <Version>
    - [ ] Vim: <Version>
