### PR TITLE
refac: use cmd history to handle auto closing

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -104,7 +104,7 @@ function! s:close_auto() abort
     let didquit = match(lastcmd, 'q')
 
     if didquit != -1
-        call s:quit_last()
+        silent! call s:quit_last()
     else
         bwipeout
     endif


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

There have been a series of bugs related to the automatic closing of the minimap.  This is because of the rather flighty behavior of the autocmds - we encounter structural hazards (some autocmds just can't do what we want directly) and obtuse design (the autocmd execution order often makes it difficult to implement what we want).

I decided to replace the auto-close system with `histget()` - the plugin will manually read the last command given, to see if it is a quitting or a buffer closing command.  This distinction was not directly possible with the previous system.  Now, manually reading command history is fragile design, but I have tested it thoroughly (to my wit's end) and it works better and more completely than whatever I had implemented prior in `close_window_last()`.

There is one known related bug: if you have a buflisted buffer open, and two nonbuflisted buffers (e.g. minimap and help windows both open), then quitting the buflisted buffer does not quit both nonbuflisted buffers.  In the specific example I gave, the help window will remain.  (However, this behavior seems to be somewhat consistent with default behavior.  That is, I was unable to find an example of it being otherwise, in default Vim or in any plugins that you'd expect to automatically close their windows as non-essential.)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5
    - [x] Vim: 8.2