### PR TITLE
feat: added highlight for visible range

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ let g:minimap_auto_start_win_enter = 1
 | `g:minimap_close_filetypes`      | `['startify', 'netrw', 'vim-plug']`                       | close minimap for specific file types                          |
 | `g:minimap_close_buftypes`       | `[]`                                                      | close minimap for specific buffer types                        |
 | `g:minimap_left`                 | `0`                                                       | if set minimap window will append left                         |
+| `g:minimap_highlight_range`      | `0`                                                       | if set minimap will highlight range of visible lines           |
 
 ### 💬 F.A.Q
 

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -56,6 +56,14 @@ g:minimap_highlight                                       *g:minimap_highlight*
   The color of the highlighting for the current position. Possible values
   are any |group-name|.
 
+g:minimap_highlight_range                           *g:minimap_highlight_range*
+
+  Type: |Number|
+  Default: `0`
+
+  If set to `1`, the minimap window will highlight over a range of lines
+  representing the visible lines in the buffer.
+
 g:minimap_auto_start                                     *g:minimap_auto_start*
 
   Type: |Number|
@@ -63,7 +71,7 @@ g:minimap_auto_start                                     *g:minimap_auto_start*
 
   If set to `1`, the minimap window will show on startup.
 
-g:minimap_auto_start_win_enter                           *g:minimap_auto_start_win_enter*
+g:minimap_auto_start_win_enter                 *g:minimap_auto_start_win_enter*
 
   Type: |Number|
   Default: `0`

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -74,6 +74,10 @@ if !exists('g:minimap_auto_start_win_enter')
     let g:minimap_auto_start_win_enter = 0
 endif
 
+if !exists('g:minimap_highlight_range')
+    let g:minimap_highlight_range = 0
+endif
+
 if g:minimap_auto_start == 1
     augroup MinimapAutoStart
         au!


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

https://github.com/wfxr/minimap.vim/issues/62#issue-836394045 mentions it might be useful to be able to highlight a range of lines in the minimap.  This patch implements an option to highlight a range of lines in the minimap - specifically, all lines visible in the main buffer.  It can be enabled with the option `g:minimap_highlight_range`.

The issue mentions totally customizing the ranges of lines that are used to highlight in the minimap.  This can be done.  If it were to be implemented, it would probably have to be relative to the buffer's line information.  This would involve function calls.  That kind of full customization can be discussed in the future.  But for now, I don't see a compelling use for absolute customization - there probably are only a few highlighting choices altogether for users.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [x] Vim: 8.2
