### PR TITLE
feat: add option to update highlight on WinScrolled

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,19 +74,20 @@ let g:minimap_auto_start_win_enter = 1
 
 ### ⚙  Options
 
-| Flag                             | Default                                                   | Description                                                    |
-|----------------------------------|-----------------------------------------------------------|----------------------------------------------------------------|
-| `g:minimap_auto_start`           | `0`                                                       | if set minimap will show at startup                            |
-| `g:minimap_auto_start_win_enter` | `0`                                                       | if set with `g:minimap_auto_start` minimap shows on `WinEnter` |
-| `g:minimap_width`                | `10`                                                      | the width of the minimap window in characters                  |
-| `g:minimap_highlight`            | `Title`                                                   | the color group for current position                           |
-| `g:minimap_base_highlight`       | `Normal`                                                  | the base color group for minimap                               |
-| `g:minimap_block_filetypes`      | `['fugitive', 'nerdtree', 'tagbar' ]`                     | disable minimap for specific file types                        |
-| `g:minimap_block_buftypes`       | `['nofile', 'nowrite', 'quickfix', 'terminal', 'prompt']` | disable minimap for specific buffer types                      |
-| `g:minimap_close_filetypes`      | `['startify', 'netrw', 'vim-plug']`                       | close minimap for specific file types                          |
-| `g:minimap_close_buftypes`       | `[]`                                                      | close minimap for specific buffer types                        |
-| `g:minimap_left`                 | `0`                                                       | if set minimap window will append left                         |
-| `g:minimap_highlight_range`      | `0`                                                       | if set minimap will highlight range of visible lines           |
+| Flag                             | Default                                                   | Description                                                          |
+|----------------------------------|-----------------------------------------------------------|----------------------------------------------------------------------|
+| `g:minimap_auto_start`           | `0`                                                       | if set minimap will show at startup                                  |
+| `g:minimap_auto_start_win_enter` | `0`                                                       | if set with `g:minimap_auto_start` minimap shows on `WinEnter`       |
+| `g:minimap_width`                | `10`                                                      | the width of the minimap window in characters                        |
+| `g:minimap_highlight`            | `Title`                                                   | the color group for current position                                 |
+| `g:minimap_base_highlight`       | `Normal`                                                  | the base color group for minimap                                     |
+| `g:minimap_block_filetypes`      | `['fugitive', 'nerdtree', 'tagbar' ]`                     | disable minimap for specific file types                              |
+| `g:minimap_block_buftypes`       | `['nofile', 'nowrite', 'quickfix', 'terminal', 'prompt']` | disable minimap for specific buffer types                            |
+| `g:minimap_close_filetypes`      | `['startify', 'netrw', 'vim-plug']`                       | close minimap for specific file types                                |
+| `g:minimap_close_buftypes`       | `[]`                                                      | close minimap for specific buffer types                              |
+| `g:minimap_left`                 | `0`                                                       | if set minimap window will append left                               |
+| `g:minimap_highlight_range`      | `0`                                                       | if set minimap will highlight range of visible lines                 |
+| `g:minimap_win_scrolled_exists`  | `0`                                                       | if set with `g:minimap_highlight_range` highlight updates on scroll  |
 
 ### 💬 F.A.Q
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Check that your encoding is set to `utf-8` and not `latin1` (for Vim users).
 Also, ensure that you're using a Unicode-compatible font that has Braille characters in it.
 
 ---
+#### What is `g:minimap_win_scrolled_exists` and how do you use it?
+
+You can have the minimap highlight all the visible lines in your current window
+by setting `g:minimap_highlight_range`.  If you use Neovim, and your version
+is recent enough (after November 7, 2020), you can set this option to update
+the highlight when the window is scrolled.
+
+---
 
 ### 📦 Related Projects
 

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -157,6 +157,7 @@ function! s:open_window() abort
                 autocmd FocusGained,WinScrolled *               call s:handle_autocmd(5)
             else
                 autocmd FocusGained,CursorMoved,CursorMovedI *  call s:handle_autocmd(5)
+            endif
         else
             autocmd FocusGained,CursorMoved,CursorMovedI *      call s:handle_autocmd(6)
         endif

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -153,7 +153,7 @@ function! s:open_window() abort
         autocmd FocusGained,CursorMoved,CursorMovedI <buffer>   call s:handle_autocmd(4)
         if g:minimap_highlight_range == 1
             " Vim and Neovim (pre-November 2020) do not have a WinScrolled autocmd event.
-            if g:minimap_win_scrolled_exists == 1
+            if has('nvim') && g:minimap_win_scrolled_exists == 1
                 autocmd FocusGained,WinScrolled *               call s:handle_autocmd(5)
             else
                 autocmd FocusGained,CursorMoved,CursorMovedI *  call s:handle_autocmd(5)

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -174,6 +174,16 @@ g:minimap_base_highlight                             *g:minimap_base_highlight*
   and check that you're using a font that is Unicode-compatible.
 
 
+|Q:|
+  What is `g:minimap_win_scrolled_exists` and how do you use it?
+
+|A:|
+  You can have the minimap highlight all the visible lines in your current window
+  by setting `g:minimap_highlight_range`.  If you use Neovim, and your version
+  is recent enough (after November 7, 2020), you can set this option to update
+  the highlight when the window is scrolled.
+
+
 LICENSE                                                       *minimap-license*
 =============================================================================
 

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -64,6 +64,16 @@ g:minimap_highlight_range                           *g:minimap_highlight_range*
   If set to `1`, the minimap window will highlight over a range of lines
   representing the visible lines in the buffer.
 
+g:minimap_win_scrolled_exists                   *g:minimap_win_scrolled_exists*
+
+  Type: |Number|
+  Default: `0`
+
+  If both this and `g:minimap_highlight_range` are set to `1`, the minimap
+  will update on the autocmd event `WinScrolled`.  This autocmd was only
+  added into versions of Neovim after November 7, 2020.  Use this only
+  if you have a version of Neovim with the autocmd!
+
 g:minimap_auto_start                                     *g:minimap_auto_start*
 
   Type: |Number|

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -78,6 +78,13 @@ if !exists('g:minimap_highlight_range')
     let g:minimap_highlight_range = 0
 endif
 
+" Warning: it is the user's job to check if they have the WinScrolled event!
+" As soon as Neovim 0.5.0 officially releases as stable, this option should be removed as 
+" every user will have the WinScrolled autocmd event.
+if !exists('g:minimap_win_scrolled_exists')
+    let g:minimap_win_scrolled_exists = 0
+endif
+
 if g:minimap_auto_start == 1
     augroup MinimapAutoStart
         au!

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -79,7 +79,7 @@ if !exists('g:minimap_highlight_range')
 endif
 
 " Warning: it is the user's job to check if they have the WinScrolled event!
-" As soon as Neovim 0.5.0 officially releases as stable, this option should be removed as 
+" As soon as Neovim 0.5.0 officially releases as stable, this option should be removed as
 " every user will have the WinScrolled autocmd event.
 if !exists('g:minimap_win_scrolled_exists')
     let g:minimap_win_scrolled_exists = 0


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

fb5a1e3 added the ability to have the minimap highlight all visible lines in the source window.  Logically such a highlight should update whenever the window is scrolled up or down, not when the cursor is moved.  However, an autocmd event that will let us implement that, `WinScrolled`, is only available in fairly recent versions of Neovim.

This patch adds an option to enable the new feature, update on window scroll, but only if you have Neovim.  It does not check for the version of Neovim, because it is impossible to delineate between specific patches of Neovim at the moment, and we need to know the specific patch to accurately determine if a user can use the feature or not.

Vim, any version, can NOT use this feature, as it lacks an equivalent autocmd as of March 19, 2021.

It may be possible to cut down the amount of math the plugin performs when updating on window scroll.  We could keep the size of the window after a resize (or initial opening), and only use the topmost visible line to calculate the start of the range with.  But the current solution is simplest, and the benefits of the change should be investigated first.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: NVIM v0.5.0-dev+1080-g971e0ca90
    - [ ] Vim: <Version>
