### PR TITLE
fix: clear wrong highlighting after exiting

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -101,9 +101,9 @@ function! s:close_auto() abort
         silent! call s:quit_last()
     else
         bwipeout
-        " In case the plugin accidentally highlights the main buffer.
-        call s:clear_highlights()
     endif
+    " In case the plugin accidentally highlights the main buffer.
+    call s:clear_highlights()
 endfunction
 
 function! s:open_window() abort


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

Always clear highlights in when minimap exits.

Related issue: #61

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: v0.5.0-dev+1239-g2e156a3b7
    - [x] Vim: 8.2 1-2653
