### PR TITLE
GH-70 - Add git sidebar coloring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ let g:minimap_auto_start_win_enter = 1
 | `g:minimap_close_buftypes`       | `[]`                                                      | close minimap for specific buffer types                              |
 | `g:minimap_left`                 | `0`                                                       | if set minimap window will append left                               |
 | `g:minimap_highlight_range`      | `0`                                                       | if set minimap will highlight range of visible lines                 |
+| `g:minimap_git_colors`           | `0`                                                       | if set minimap will highlight range of changes as reported by git    |
+| `g:minimap_diffadd_color`        | `diffAdded`                                               | the color group for added lines (if git_colors is enabled)           |
+| `g:minimap_diffremove_color`     | `diffRemoved`                                             | the color group for removed lines (if git_colors is enabled)         |
+| `g:minimap_diff_color`           | `diffLine`                                                | the color group for modified lines (if git_colors is enabled)        |
 
 ### 💬 F.A.Q
 

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -78,6 +78,22 @@ if !exists('g:minimap_highlight_range')
     let g:minimap_highlight_range = 0
 endif
 
+if !exists('g:minimap_git_colors')
+    let g:minimap_git_colors = 0
+endif
+
+if !exists('g:minimap_diffadd_color')
+    let g:minimap_diffadd_color = 'diffAdded'
+endif
+
+if !exists('g:minimap_diffremove_color')
+    let g:minimap_diffremove_color = 'diffRemoved'
+endif
+
+if !exists('g:minimap_diff_color')
+    let g:minimap_diff_color = 'diffLine'
+endif
+
 if g:minimap_auto_start == 1
     augroup MinimapAutoStart
         au!


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [X] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [X] I have searched through the existing issues or pull requests
- [X] I have performed a self-review of my code and commented hard-to-understand areas
- [X] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->
This implements GH-70 - Adding git coloration to the minimiap. New feature is disabled by default, so users should not notice a difference unless the feature is explicitly enabled.

### Implementation details
The git diff is retrieved for the current file, and the diff blobs are parsed to determine the range and types of changes. Unfortunately, I did not see a way to retrieve just the git blobs. In an effort to cut down the amount of text parsed, the `-U0` option is passed to git, requesting just the changes with no additional context.

A list of IDs is created when coloring each section. The list needs to be kept around so we can clear out the IDs the next time the minimap is updated. The list just increments to the next ID - I don't have a whole lot of experience with id matching to know if that will cause a problem, but it seemed to work just fine during my testing.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [X] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [X] Neovim: NVIM v0.5.0-dev+1353-g0a653f7ab
    - [ ] Vim: <Version>
