### PR TITLE
Fix GH-74 - Close minimap when CoC has a floating window up

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -93,7 +93,10 @@ function! s:quit_last() abort
 endfunction
 
 function! s:close_auto() abort
-    if winnr('$') != 1
+    if winnr('$') == 3 && exists('g:coc_last_float_win')
+        " This addresses an issue where the minimap will not close
+        " if CoC has a diagnostic window open - GH-74
+    elseif winnr('$') != 1
         return
     endif
 


### PR DESCRIPTION
Update git_color defaults<!-- Check all that apply [x] -->

## Check list

- [X] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [X] I have searched through the existing issues or pull requests
- [X] I have performed a self-review of my code and commented hard-to-understand areas
- [X] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->
Fixes GH-74

For some reason when CoC has a diagnostic window open, both the main window and the diagnostic window are still open when the `WinEnter <buffer>` autocmd fires. The result is `winnr('$')` returns 3 instead of the 1 required for closing. I fixed this by checking for `g:coc_last_float_win` - a variable that only exists when a floating window is active. When a floating window exists, the expected number of windows when closing the last window is 3. This change will close the minimap in that case.

CoC has many documented differences between Neovim 0.5.0 and Vim 8. It's possible this does not work/causes an issue when using Vim 8. I do not have Vim 8 installed, so I did not test with it yet. I will try to get that set up so I can test, but if a reviewer gets to this before then, please check that before approving.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [X] Neovim: NVIM v0.5.0-dev+1353-g0a653f7ab
    - [ ] Vim: <Version>
