### PR TITLE
GH-76 - Fix single added line showing up as 'diff' (instead of 'added')

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -397,13 +397,13 @@ function! s:update_highlight() abort
                 " Parse newfile info
                 let add_info = split(add_info, ',')
                 let add_start = str2nr(add_info[0])
-                let add_len = 0
+                let add_len = 1
                 if len(add_info) > 1
                     let add_len = abs(str2nr(add_info[1]))
                 endif
                 " Parse oldfile info
                 let del_info = split(del_info, ',')
-                let del_len = 0
+                let del_len = 1
                 if len(del_info) > 1
                     let del_len = abs(str2nr(del_info[1]))
                 endif


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [X] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [X] I have searched through the existing issues or pull requests
- [X] I have performed a self-review of my code and commented hard-to-understand areas
- [X] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->
Fixes GH-76.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [X] Neovim: 0.5.0 nightly
    - [ ] Vim: <Version>
