### PR TITLE
Fix clearing on search in certain situations 

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -413,7 +413,8 @@ endfunction
 
 function! minimap#vim#ClearColorSearch() abort
     if exists('g:minimap_search_id_list')
-        call s:clear_id_list_colors(0, g:minimap_search_id_list)
+        let win_info = s:get_window_info()
+        call s:clear_id_list_colors(win_info['winid'], g:minimap_search_id_list)
         let g:minimap_search_id_list = []
     endif
 endfunction


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [ ] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

I noticed sometimes the highlighted searches in the minimap do not get cleared. I think this occurs when I open windows in a slightly different order. I added the minimap id as an explicit target to fix this.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [ ] Vim: <Version>
