### PR TITLE
Preserve 'previous buffer' when opening the minimap

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -116,6 +116,10 @@ function! s:open_window() abort
         return
     endif
 
+    " Preserve 'previous buffer' when opening the minimap
+    let prev_buffer = bufnr('#')
+    let curr_buffer = bufnr()
+
     let openpos = g:minimap_left ? 'topleft vertical ' : 'botright vertical '
     noautocmd execute 'silent! ' . openpos . g:minimap_width . 'split ' . '-MINIMAP-'
 
@@ -185,6 +189,10 @@ function! s:open_window() abort
     execute 'wincmd p'
     call s:refresh_minimap(1)
     call s:update_highlight()
+
+    " Restore buffer orders
+    execute(prev_buffer . 'buffer')
+    execute(curr_buffer . 'buffer')
 endfunction
 
 function! s:handle_autocmd(cmd) abort


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

Closes #89  

When opening the minimap, we now save the current and previous buffer numbers, then restore them once the minimap is open. This preserves `<C-^>` behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5
    - [ ] Vim: <Version>
