### PR TITLE
GH-95 - Lock out autocmds while in the process of opening the minimap

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -437,6 +437,9 @@ function! s:update_highlight() abort
         return
     endif
 
+    " For unit tests. Very little ovehead so not gating it
+    let g:minimap_run_update_highlight_count = g:minimap_run_update_highlight_count + 1
+
     if g:minimap_highlight_range
         let startln = line('w0') - 1
         let endln = line('w$') - 1

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -116,6 +116,8 @@ function! s:open_window() abort
         return
     endif
 
+    let g:minimap_opening = 1
+
     " Preserve 'previous buffer' when opening the minimap
     let prev_buffer = bufnr('#')
     let curr_buffer = bufnr()
@@ -193,33 +195,37 @@ function! s:open_window() abort
     " Restore buffer orders
     execute(prev_buffer . 'buffer')
     execute(curr_buffer . 'buffer')
+
+    let g:minimap_opening = 0
 endfunction
 
 function! s:handle_autocmd(cmd) abort
-    if s:closed_on()
-        let mmwinnr = bufwinnr('-MINIMAP-')
-        if mmwinnr != -1
-            call s:close_window()
+    if g:minimap_opening == 0
+        if s:closed_on()
+            let mmwinnr = bufwinnr('-MINIMAP-')
+            if mmwinnr != -1
+                call s:close_window()
+            endif
+        elseif s:ignored()
+            return
+        elseif a:cmd == 0           " WinEnter <buffer>
+            call s:close_auto()
+        elseif a:cmd == 1           " WinEnter *
+            " If previously triggered minimap_did_quit, untrigger it
+            let g:minimap_did_quit = 0
+            call s:win_enter_handler()
+        elseif a:cmd == 2           " BufWritePost,VimResized *
+            call s:refresh_minimap(1)
+            call s:update_highlight()
+        elseif a:cmd == 3           " BufEnter,FileType *
+            call s:buffer_enter_handler()
+        elseif a:cmd == 4           " FocusGained,CursorMoved,CursorMovedI <buffer>
+            call s:minimap_move()
+        elseif a:cmd == 5           " FocusGained,WinScrolled * (neovim); else same autocmds as below
+            call s:source_win_scroll()
+        elseif a:cmd == 6           " FocusGained,CursorMoved,CursorMovedI *
+            call s:source_move()
         endif
-    elseif s:ignored()
-        return
-    elseif a:cmd == 0           " WinEnter <buffer>
-        call s:close_auto()
-    elseif a:cmd == 1           " WinEnter *
-        " If previously triggered minimap_did_quit, untrigger it
-        let g:minimap_did_quit = 0
-        call s:win_enter_handler()
-    elseif a:cmd == 2           " BufWritePost,VimResized *
-        call s:refresh_minimap(1)
-        call s:update_highlight()
-    elseif a:cmd == 3           " BufEnter,FileType *
-        call s:buffer_enter_handler()
-    elseif a:cmd == 4           " FocusGained,CursorMoved,CursorMovedI <buffer>
-        call s:minimap_move()
-    elseif a:cmd == 5           " FocusGained,WinScrolled * (neovim); else same autocmds as below
-        call s:source_win_scroll()
-    elseif a:cmd == 6           " FocusGained,CursorMoved,CursorMovedI *
-        call s:source_move()
     endif
 endfunction
 
@@ -247,7 +253,6 @@ function! s:refresh_minimap(force) abort
     let bufnr = bufnr('%')
     let fname = fnamemodify(bufname('%'), ':p')
     let mmwinnr = bufwinnr('-MINIMAP-')
-
     if mmwinnr == -1
         return
     endif

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -120,8 +120,9 @@ if !exists('g:minimap_search_color_priority')
     let g:minimap_search_color_priority = 120
 endif
 
-" Define mutex
+" Define mutexes
 let g:minimap_getting_window_info = 0
+let g:minimap_opening = 0
 " Define id lists - used for storing matchids of color groups
 let g:minimap_range_id_list = []
 let g:minimap_git_id_list = []

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -120,13 +120,15 @@ if !exists('g:minimap_search_color_priority')
     let g:minimap_search_color_priority = 120
 endif
 
-" Define mutexes
+" Declare mutexes
 let g:minimap_getting_window_info = 0
 let g:minimap_opening = 0
-" Define id lists - used for storing matchids of color groups
+" Declare id lists - used for storing matchids of color groups
 let g:minimap_range_id_list = []
 let g:minimap_git_id_list = []
 let g:minimap_search_id_list = []
+" Declare unit test specific items
+let g:minimap_run_update_highlight_count = 0
 
 if g:minimap_auto_start == 1
     augroup MinimapAutoStart

--- a/t/utility_tests.vim
+++ b/t/utility_tests.vim
@@ -12,4 +12,21 @@ function! s:minimap_test_utility()
     call testify#assert#equals(actual_mm, expected_mm)
 endfunction
 
-call testify#it('Utility tests', function('s:minimap_test_utility'))
+function! s:minimap_test_calls_to_update_minimap()
+    " Save minimap state
+    let mmwinnr = bufwinnr('-MINIMAP-')
+
+    call minimap#vim#MinimapClose()
+    let g:minimap_run_update_highlight_count = 0
+    call minimap#vim#MinimapOpen()
+    call testify#assert#equals(1, g:minimap_run_update_highlight_count)
+
+    if mmwinnr == -1
+        call minimap#vim#MinimapClose()
+    endif
+endfunction
+
+call testify#it('Minimap conversion math works as expected',
+            \ function('s:minimap_test_utility'))
+call testify#it('Opening minimap restults in only one call to update_minimap',
+            \ function('s:minimap_test_calls_to_update_minimap'))


### PR DESCRIPTION
Previously were making 5 update calls to open the minimap. Reduced that
to 1 by putting in a mutex - locked when opening the minimap.
I didn't make any measurements, but anecdotally, it is much faster.

<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

Add a mutex to reduce the calls to `s:update_highlight()` when opening the minimap.
Closes #95 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5
    - [ ] Vim: <Version>
