### PR TITLE
NOTICKET - Fix clearing search highlights when minimap is closed

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -665,8 +665,10 @@ endfunction
 function! minimap#vim#ClearColorSearch() abort
     if exists('g:minimap_search_id_list')
         let win_info = s:get_window_info()
-        call s:clear_id_list_colors(win_info['winid'], g:minimap_search_id_list)
-        let g:minimap_search_id_list = []
+        if win_info != {}
+            call s:clear_id_list_colors(win_info['winid'], g:minimap_search_id_list)
+            let g:minimap_search_id_list = []
+        endif
     endif
 endfunction
 function! minimap#vim#UpdateColorSearch(query) abort


### PR DESCRIPTION

## Description

Stumbled across this while doing other things, minimap.vim throws an error if you try to clear the colors when there is no minimap up.
