### PR TITLE
Quote minimap_gen command path

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -274,13 +274,13 @@ function! s:generate_minimap(mmwinnr, bufnr, fname, ftype) abort
     let userflag = &shellcmdflag
     let &shell = s:default_shell
     let &shellcmdflag = s:default_shellflag
-
+    let minimap_cmd = '"'.s:minimap_gen.'"'
     if has('nvim')
-        let minimap_cmd = 'w !'.s:minimap_gen.' '.hscale.' '.vscale.' '.g:minimap_width
+        let minimap_cmd = 'w !'.minimap_cmd.' '.hscale.' '.vscale.' '.g:minimap_width
         " echom minimap_cmd
         let minimap_output = execute(minimap_cmd) " Not work for vim 8.2 ?
     else
-        let minimap_cmd = s:minimap_gen.' '.hscale.' '.vscale.' '.g:minimap_width
+        let minimap_cmd = minimap_cmd.' '.hscale.' '.vscale.' '.g:minimap_width
         " echom minimap_cmd
         let minimap_output = system(minimap_cmd, join(getline(1, '$'), "\n"))
     endif


### PR DESCRIPTION
It was previously failing to execute if the path contained invalid
characters (e.g. spaces).

<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [ ] I have verified all existing unit tests pass (See the README on how to run)
- [ ] I have added new tests if appropriate
- [ ] I have performed a self-review of my code and commented hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (when necessary)

## Description

The plugin was previously failing to execute the minimap generation command if the path to the binary contained characters that the shell would interpret as a word splitter. This change quotes commands before running them.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [ ] Vim: <Version>

There are some failing tests, but don't think they're related to this change. They appear to fail with the same reason even without a working minimap:
```
✗ Search - Beginning of file
	Expected "[]" to equal "[[1, 1, 3], [3, 4, 3], [3, 10, 3], [3, 13, 3]]"
		<SNR>72_minimap_test_search_beginning_of_file:5
✗ Search - Beginning of line
	Expected "[]" to equal "[[1, 4, 3], [3, 1, 3], [3, 1, 3]]"
		<SNR>72_minimap_test_search_beginning_of_line:7
✗ Search - End of line
	Expected "[]" to equal "[[1, 4, 3], [3, 7, 3]]"
		<SNR>72_minimap_test_search_end_of_line:5
✗ Search - Multi match per line
	Expected "[]" to equal "[[3, 4, 3], [3, 16, 3], [3, 22, 3]]"
		<SNR>72_minimap_test_search_multi_per_line:5
√ Search - Spanning a line
✗ Search - Many results
	Expected "[]" to equal "[[1, 1, 3], [1, 4, 3], [1, 19, 3], [1, 22, 3], [1, 25, 3], [1, 25, 3], [1, 1, 3], [1, 1, 3], [1, 1, 3], [2, 1, 3], [2, 1, 3], [2, 1, 3], [2, 1, 3], [3, 1, 3], [3, 1, 3], [3, 1, 3], [3, 1, 3], [3, 1, 3], [3, 16, 3]]"
		<SNR>72_minimap_test_search_many_results:8
✗ Search - Long Match
	Expected "[]" to equal "[[1, 7, 21]]"
		<SNR>72_minimap_test_search_long_match:5
✗ Search - History
	Expected "[]" to equal "[[1, 1, 3], [1, 1, 3], [1, 1, 3], [2, 1, 3], [2, 1, 3], [2, 1, 3], [2, 1, 3], [3, 1, 3], [3, 1, 3]]"
		<SNR>72_minimap_test_search_history:11
```