### PR TITLE
Fix windows line endings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,10 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        # os: [ windows-2022, ubuntu-20.04 ]
-        os: [ ubuntu-20.04 ]
+        os: [ windows-2022, ubuntu-20.04 ]
         include:
-          # - os: windows-2022
-          #   NEOVIM_CONFIG_PATH: ~/AppData/Local/nvim
+          - os: windows-2022
+            NEOVIM_CONFIG_PATH: ~/AppData/Local/nvim
           - os: ubuntu-20.04
             NEOVIM_CONFIG_PATH: $HOME/.config/nvim
     runs-on: ${{ matrix.os }}
@@ -45,11 +44,11 @@ jobs:
           mkdir -p "$HOME/bin"
           ln -s /bin/echo "$HOME/bin/code-minimap"
           echo "$HOME/bin" >> $GITHUB_PATH
-      # - if: ${{ contains(matrix.os, 'windows') }}
-      #   name: Create a fake code-minimap executable (Windows)
-      #   run: |
-      #     mkdir -p ~/bin
-      #     cp  C:/Windows/System32/doskey.exe ~/bin/code-minimap.exe
+      - if: ${{ contains(matrix.os, 'windows') }}
+        name: Create a fake code-minimap executable (Windows)
+        run: |
+          mkdir -p ~/bin
+          cp  C:/Windows/System32/doskey.exe ~/bin/code-minimap.exe
 
       - name: Checkout Testify
         run: |

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -785,9 +785,17 @@ endfunction
 function! s:minimap_color_git(win_info) abort
     " Get git info
     let git_call = 'git diff -U0 -- ' . expand('%')
-    let git_diff = substitute(system(git_call), '\n\+&', '', '') | silent echo strtrans(git_diff)
+    let newline_char = '\n'
+    if has('win32')
+        let newline_char = '\r\n'
+    endif
+    let git_diff = substitute(system(git_call), newline_char . '\+&', '', '') | silent echo strtrans(git_diff)
 
-    let lines = split(git_diff, '\n')
+    let split_char = '\n'
+    if has('win32')
+        let split_char = '\r\n'
+    endif
+    let lines = split(git_diff, split_char)
     let diff_list = []
     for line in lines
         if line[0] ==? '@'
@@ -855,7 +863,11 @@ function! s:minimap_color_search_get_spans(win_info, query) abort
     if type(a:query) != type(0)
         let last_search = a:query
     else
-        let tmp = split(execute('his /'), '\n')
+        let split_char = '\n'
+        if has('win32')
+            let split_char = '\r\n'
+        endif
+        let tmp = split(execute('his /'), split_char)
         let tmp = split(tmp[len(tmp)-a:query], '', 1)
         " echom 'tmp: ' . join(tmp)
         let last_search = join(tmp[2:-1])

--- a/t/search_tests.vim
+++ b/t/search_tests.vim
@@ -11,19 +11,23 @@ let s:testfile = expand('%')
 
 " Search tests
 function! s:minimap_test_search()
-    " Create the subjest of our search
+    " Create the subject of our search
+    let newline_char = '\n'
+    if has('win32')
+        let newline_char = '\r\n'
+    endif
     let test_file = '/tmp/minimap_search_unit_test_file'
-    let text =        'This is a test line and it needs to be long enough to register as multiple braille characters.\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'And another, this one is shorter\n'
+    let text =        'This is a test line and it needs to be long enough to register as multiple braille characters.' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'pad height' . newline_char
+    let text = text . 'And another, this one is shorter' . newline_char
     let text = text . 'and flows to the numbers line, this one, this one has some numbers 1234 numbers'
     execute 'silent !echo "' . text . '" > ' . test_file
     execute 'edit ' . test_file
@@ -61,7 +65,11 @@ function! s:minimap_test_search_multi_per_line()
 endfunction
 function! s:minimap_test_search_spanning_a_line()
     " Spanning a line (should be empty, not supported yet)
-    let search = 'shorter\nand flows'
+    let newline_char = '\n'
+    if has('win32')
+        let newline_char = '\r\n'
+    endif
+    let search = 'shorter' . newline_char . 'and flows'
     let expected_list = [ ]
     let actual_list = minimap#vim#MinimapColorSearchGetSpans(s:win_info, search)
     call testify#assert#equals(actual_list, expected_list)


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

A couple places assumed unix line endings, but the Search function/unit
tests heavily relied on it. This commit detects the platform and changes
the used line endings accordingly.

Fixes #101 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5
    - [ ] Vim: <Version>
