### PR TITLE
Fix winscrolled event (change `has` check to `exists`)

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -162,7 +162,7 @@ function! s:open_window() abort
         autocmd FocusGained,CursorMoved,CursorMovedI <buffer>   call s:handle_autocmd(4)
         if g:minimap_highlight_range == 1
             " Vim and Neovim (pre-November 2020) do not have a WinScrolled autocmd event.
-            if has('##WinScrolled')
+            if exists('##WinScrolled')
                 autocmd FocusGained,WinScrolled *               call s:handle_autocmd(5)
             else
                 autocmd FocusGained,CursorMoved,CursorMovedI *  call s:handle_autocmd(5)


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

Fixes WinScroll autocmd mapping (#111)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5
    - [ ] Vim: <Version>
