### PR TITLE
fix(documentation): incorrect highlight references

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Minimap.vim sets its own color groups to give a reasonable default.
 
 You can create your own colorgroup by specifying the foreground and background colors for the cterm or gui:
 ```
-:highlight mmCursor ctermbg=59  ctermfg=228 guibg=#5F5F5F guifg=#FFFF87
+:highlight minimapCursor ctermbg=59  ctermfg=228 guibg=#5F5F5F guifg=#FFFF87
 ```
 
 For more information, see `:help highlight`
@@ -119,8 +119,8 @@ For more information, see `:help highlight`
 note: some colorschemes will clear all previous colors, so you may have to add an `autocmd` to ensure your custom colorgroups are added back:
 ```
 autocmd ColorScheme *
-        \ highlight mmCursor            ctermbg=59  ctermfg=228 guibg=#5F5F5F guifg=#FFFF87 |
-        \ highlight mmRange             ctermbg=242 ctermfg=228 guibg=#4F4F4F guifg=#FFFF87
+        \ highlight minimapCursor            ctermbg=59  ctermfg=228 guibg=#5F5F5F guifg=#FFFF87 |
+        \ highlight minimapRange             ctermbg=242 ctermfg=228 guibg=#4F4F4F guifg=#FFFF87
 ```
 
 ### 💬 F.A.Q


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [X] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [ ] I have searched through the existing issues or pull requests
- [ ] I have verified all existing unit tests pass (See the README on how to run)
- [ ] I have added new tests if appropriate
- [ ] I have performed a self-review of my code and commented hard-to-understand areas
- [X] I have made corresponding changes to the documentation (when necessary)

## Description

Incorrect highlight group references

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [X] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [ ] Neovim: <Version>
    - [ ] Vim: <Version>
