### PR TITLE
GH-122 - Add customization for mm scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,22 @@ let g:minimap_auto_start_win_enter = 1
 
 ### ⚙  Options
 
-| Flag                                | Default                                                   | Description                                                          |
-|-------------------------------------|-----------------------------------------------------------|----------------------------------------------------------------------|
-| `g:minimap_auto_start`              | `0`                                                       | if set minimap will show at startup                                  |
-| `g:minimap_auto_start_win_enter`    | `0`                                                       | if set with `g:minimap_auto_start` minimap shows on `WinEnter`       |
-| `g:minimap_width`                   | `10`                                                      | the width of the minimap window in characters                        |
-| `g:minimap_base_highlight`          | `Normal`                                                  | the base color group for minimap                                     |
-| `g:minimap_block_filetypes`         | `['fugitive', 'nerdtree', 'tagbar', 'fzf' ]`              | disable minimap for specific file types                              |
-| `g:minimap_block_buftypes`          | `['nofile', 'nowrite', 'quickfix', 'terminal', 'prompt']` | disable minimap for specific buffer types                            |
-| `g:minimap_close_filetypes`         | `['startify', 'netrw', 'vim-plug']`                       | close minimap for specific file types                                |
-| `g:minimap_close_buftypes`          | `[]`                                                      | close minimap for specific buffer types                              |
-| `g:minimap_left`                    | `0`                                                       | if set minimap window will append left                               |
-| `g:minimap_highlight_range`         | `0`                                                       | if set minimap will highlight range of visible lines                 |
-| `g:minimap_highlight_search`        | `0`                                                       | if set minimap will highlight searched patterns                      |
-| `g:minimap_git_colors`              | `0`                                                       | if set minimap will highlight range of changes as reported by git    |
+| Flag                                          | Default                                                   | Description                                                          |
+|-------------------------------------------    |-----------------------------------------------------------|----------------------------------------------------------------------|
+| `g:minimap_auto_start`                        | `0`                                                       | if, set minimap will show at startup                                 |
+| `g:minimap_auto_start_win_enter`              | `0`                                                       | if, set with `g:minimap_auto_start` minimap shows on `WinEnter`      |
+| `g:minimap_width`                             | `10`                                                      | the width of the minimap window in characters                        |
+| `g:minimap_window_width_cap`                  | `120`                                                     | the width cap for scaling the minimap (see minimap.txt help file)    |
+| `g:minimap_window_width_override_for_scaling` | `2147483647`                                              | tunes the behavior of long lines (see minimap.txt help file)         |
+| `g:minimap_base_highlight`                    | `Normal`                                                  | the base color group for minimap                                     |
+| `g:minimap_block_filetypes`                   | `['fugitive', 'nerdtree', 'tagbar', 'fzf' ]`              | disable minimap for specific file types                              |
+| `g:minimap_block_buftypes`                    | `['nofile', 'nowrite', 'quickfix', 'terminal', 'prompt']` | disable minimap for specific buffer types                            |
+| `g:minimap_close_filetypes`                   | `['startify', 'netrw', 'vim-plug']`                       | close minimap for specific file types                                |
+| `g:minimap_close_buftypes`                    | `[]`                                                      | close minimap for specific buffer types                              |
+| `g:minimap_left`                              | `0`                                                       | if set, minimap window will append left                              |
+| `g:minimap_highlight_range`                   | `0`                                                       | if set, minimap will highlight range of visible lines                |
+| `g:minimap_highlight_search`                  | `0`                                                       | if set, minimap will highlight searched patterns                     |
+| `g:minimap_git_colors`                        | `0`                                                       | if set, minimap will highlight range of changes as reported by git   |
 
 ### ⚙  Color Options
 Minimap.vim sets its own color groups to give a reasonable default.

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -287,8 +287,10 @@ function! s:generate_minimap(mmwinnr, bufnr, fname, ftype) abort
     else
         " The minimap loses detail if we go beyond 120, so cap it there.
         " It's ok to cap it smaller because we don't wrap.
-        let denom = min([winwidth, 120])
+        let denom = min([winwidth, g:minimap_window_width_cap])
     endif
+    " Let users override the max width. By default, this does nothing.
+    let denom = min([denom, g:minimap_window_width_override_for_scaling])
 
     let hscale = string(2.0 * g:minimap_width / denom)
     let vscale = string(4.0 * winheight(s:win_info['mmwinid']) / line('$'))
@@ -495,17 +497,15 @@ function! s:get_window_info() abort
         let mmwinid = win_getid(mmwinnr)
         let height = line('$')
         let max_width = 0
-        if g:minimap_highlight_search
-            " Get the max width of this buffer
-            let line_num = 1
-            while line_num <= line('$')
-                call setpos('.', [0, line_num, 1])
-                " Move cursor to the last non-blank character on the line
-                normal! g_
-                let max_width = max([max_width, col('.')])
-                let line_num = line_num + 1
-            endwhile
-        endif
+        " Get the max width of this buffer
+        let line_num = 1
+        while line_num <= line('$')
+            call setpos('.', [0, line_num, 1])
+            " Move cursor to the last non-blank character on the line
+            normal! g_
+            let max_width = max([max_width, col('.')])
+            let line_num = line_num + 1
+        endwhile
 
         " Go to the minimap
         call win_gotoid(mmwinid)

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -291,6 +291,8 @@ function! s:generate_minimap(mmwinnr, bufnr, fname, ftype) abort
     endif
     " Let users override the max width. By default, this does nothing.
     let denom = min([denom, g:minimap_window_width_override_for_scaling])
+    " Protect against divide by 0 or negative hscale - denom must be > 0
+    let denom = max([denom, 1])
 
     let hscale = string(2.0 * g:minimap_width / denom)
     let vscale = string(4.0 * winheight(s:win_info['mmwinid']) / line('$'))

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -48,6 +48,47 @@ g:minimap_width                                               *g:minimap_width*
 
   The width of the minimap window in characters.
 
+g:minimap_window_width_cap                         *g:minimap_window_width_cap*
+
+  Type: |Number|
+  Default: `120`
+
+  Caps the window width for scaling the minimap.
+
+  A smaller value will give more granular details for short lines at the cost
+  of 'washing out' long lines. A larger value will give more accurate scaling
+  at the cost of losing details in short lines.
+  This value is overridden by `g:minimap_window_width_override_for_scaling` if
+  that value is set lower than this one.
+
+g:minimap_window_width_override_for_scaling *g:minimap_window_width_override_for_scaling*
+
+  Type: |Number|
+  Default: `2147483647`
+
+  Overrides the scaling behavior. Typically used for buffers that have long
+  lines relative to the rest of the lines in the buffer, but if set low enough
+  it will also affect 'normal' scaling.
+  Under 'normal' circumstances (i.e. no relatively long lines), the value in
+  practice is 120. When there is a relatively long line in the buffer, the
+  value is the length of the longest line in the buffer. This gives proper
+  scaling behavior, but may not look good.
+  The result of this value being used is a minimap that scrolls horizontally —
+  any lines that are longer than this value will extend past the end of the
+  minimap window width. In some cases, the minimap will shift the 'viewport'
+  to the right, resulting in _only_ the long lines being shown, which is why
+  the default scaling behavior is to fit long lines in the window width.
+
+  A couple notes on how this setting interacts with the rest of minimap.vim:
+    - The default of 120 is used on any buffer that does not have a line that
+      extends past the end of the window (or is wrapped). This means using a
+      larger vim window may prevent undesireable scaling behavior.
+    - The minimap's horizontal scale is also based off the minimap's width
+      (`g:minimap_width`). Increasing this will allow more room for horizontal
+      details.
+    - This value will override `g:minimap_window_width_cap` if set to a lower
+      value.
+
 g:minimap_highlight_range                           *g:minimap_highlight_range*
 
   Type: |Number|

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -37,6 +37,14 @@ if !exists('g:minimap_width')
     let g:minimap_width = 10
 endif
 
+if !exists('g:minimap_window_width_override_for_scaling')
+    let g:minimap_window_width_override_for_scaling = 2147483647
+endif
+
+if !exists('g:minimap_window_width_cap')
+    let g:minimap_window_width_cap = 120
+endif
+
 if !exists('g:minimap_auto_start_win_enter')
     let g:minimap_auto_start_win_enter = 0
 endif


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

closes #122
closes #127 

- Adds additional settings for minimap scale control.
- Fixes buffer width not being calculated if search mode is turned off.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5
    - [ ] Vim: <Version>
