### PR TITLE
GH-121 - Fix highlighting and minimap scaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /doc/tags
+.vim/

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ let g:minimap_auto_start_win_enter = 1
 | `g:minimap_auto_start`                        | `0`                                                       | if, set minimap will show at startup                                 |
 | `g:minimap_auto_start_win_enter`              | `0`                                                       | if, set with `g:minimap_auto_start` minimap shows on `WinEnter`      |
 | `g:minimap_width`                             | `10`                                                      | the width of the minimap window in characters                        |
-| `g:minimap_window_width_cap`                  | `120`                                                     | the width cap for scaling the minimap (see minimap.txt help file)    |
-| `g:minimap_window_width_override_for_scaling` | `2147483647`                                              | tunes the behavior of long lines (see minimap.txt help file)         |
+| `g:minimap_window_width_override_for_scaling` | `2147483647`                                              | the width cap for scaling the minimap (see minimap.txt help file)    |
 | `g:minimap_base_highlight`                    | `Normal`                                                  | the base color group for minimap                                     |
 | `g:minimap_block_filetypes`                   | `['fugitive', 'nerdtree', 'tagbar', 'fzf' ]`              | disable minimap for specific file types                              |
 | `g:minimap_block_buftypes`                    | `['nofile', 'nowrite', 'quickfix', 'terminal', 'prompt']` | disable minimap for specific buffer types                            |

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -48,46 +48,28 @@ g:minimap_width                                               *g:minimap_width*
 
   The width of the minimap window in characters.
 
-g:minimap_window_width_cap                         *g:minimap_window_width_cap*
-
-  Type: |Number|
-  Default: `120`
-
-  Caps the window width for scaling the minimap.
-
-  A smaller value will give more granular details for short lines at the cost
-  of 'washing out' long lines. A larger value will give more accurate scaling
-  at the cost of losing details in short lines.
-  This value is overridden by `g:minimap_window_width_override_for_scaling` if
-  that value is set lower than this one.
-
 g:minimap_window_width_override_for_scaling *g:minimap_window_width_override_for_scaling*
 
   Type: |Number|
   Default: `2147483647`
 
-  Overrides the scaling behavior. Typically used for buffers that have long
-  lines relative to the rest of the lines in the buffer, but if set low enough
-  it will also affect 'normal' scaling.
-  Under 'normal' circumstances (i.e. no relatively long lines), the value in
-  practice is 120. When there is a relatively long line in the buffer, the
-  value is the length of the longest line in the buffer. This gives proper
-  scaling behavior, but may not look good.
-  The result of this value being used is a minimap that scrolls horizontally —
-  any lines that are longer than this value will extend past the end of the
-  minimap window width. In some cases, the minimap will shift the 'viewport'
-  to the right, resulting in _only_ the long lines being shown, which is why
-  the default scaling behavior is to fit long lines in the window width.
+  Caps the window width for scaling the minimap.
 
-  A couple notes on how this setting interacts with the rest of minimap.vim:
-    - The default of 120 is used on any buffer that does not have a line that
-      extends past the end of the window (or is wrapped). This means using a
-      larger vim window may prevent undesireable scaling behavior.
-    - The minimap's horizontal scale is also based off the minimap's width
-      (`g:minimap_width`). Increasing this will allow more room for horizontal
-      details.
-    - This value will override `g:minimap_window_width_cap` if set to a lower
-      value.
+  A smaller value will give more granular details for short lines at the cost
+  of generating a minimap wider than the minimap window. A larger value will
+  give more accurate scaling at the cost of losing details in short lines.
+
+  The result of this value being used (i.e. the width getting capped) is a
+  minimap that scrolls horizontally — any lines that are longer than this value
+  will extend past the end of the minimap window width. In some cases, the
+  minimap will shift the 'viewport' to the right, resulting in _only_ the long
+  lines being shown, which is why the default scaling behavior is to fit long
+  lines in the window width.
+
+  The minimap's horizontal scale is also based off the minimap's width
+  (`g:minimap_width`). Increasing this will allow more room for horizontal
+  details.
+
 
 g:minimap_highlight_range                           *g:minimap_highlight_range*
 

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -41,10 +41,6 @@ if !exists('g:minimap_window_width_override_for_scaling')
     let g:minimap_window_width_override_for_scaling = 2147483647
 endif
 
-if !exists('g:minimap_window_width_cap')
-    let g:minimap_window_width_cap = 120
-endif
-
 if !exists('g:minimap_auto_start_win_enter')
     let g:minimap_auto_start_win_enter = 0
 endif

--- a/t/search_tests.vim
+++ b/t/search_tests.vim
@@ -4,7 +4,7 @@
 
 " Define the minimap dimensions
 let s:win_info = { 'winid': 0, 'height': 12, 'mm_height': 3,
-                \ 'max_width': 91, 'mm_max_width': 9}
+                \ 'working_width': 91, 'mm_max_width': 9}
 " Save the current view for restoring
 let s:testview = winsaveview()
 let s:testfile = expand('%')


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

fixes #121 

We were stuck in an in-between scaling strategy. I took out some of the more
complicated "cap under this situation, but not that one" in favor of a minimap
that just scales accurately. I left in a setting for people to use to override
this behavior.

Simplifying this scaling behavior fixes Search highlighting not working in certain situations — we now have a single scaling strategy that search can map on to.

Also found/fixed a bug where it would take two saves to actually re-render the minimap.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Improvement of existing features
- [x] Refactor
- [ ] Breaking change
- [x] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: v0.6.0
    - [ ] Vim: <Version>
