### PR TITLE
GH-133 - Fix entering minimap via wincommand causing the cursor to jump

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -222,21 +222,28 @@ function! s:handle_autocmd(cmd) abort
         elseif s:ignored()
             return
         elseif a:cmd == 0           " WinEnter <buffer>
+            " echom 'WinEnter <buffer>'
             call s:close_auto()
         elseif a:cmd == 1           " WinEnter *
+            " echom 'WinEnter *'
             " If previously triggered minimap_did_quit, untrigger it
             let g:minimap_did_quit = 0
             call s:win_enter_handler()
         elseif a:cmd == 2           " BufWritePost,VimResized *
+            " echom 'BufWritePost,VimResized *'
             call s:refresh_minimap(1)
             call s:update_highlight()
         elseif a:cmd == 3           " BufEnter,FileType *
+            " echom 'BufEnter,FileType *'
             call s:buffer_enter_handler()
         elseif a:cmd == 4           " FocusGained,CursorMoved,CursorMovedI <buffer>
+            " echom 'FocusGained,CursorMoved,CursorMovedI <buffer>'
             call s:minimap_move()
         elseif a:cmd == 5           " FocusGained,WinScrolled * (neovim); else same autocmds as below
+            " echom 'FocusGained,WinScrolled * (neovim); else same autocmds as below'
             call s:source_win_scroll()
         elseif a:cmd == 6           " FocusGained,CursorMoved,CursorMovedI *
+            " echom 'FocusGained,CursorMoved,CursorMovedI *'
             call s:source_move()
         endif
     endif
@@ -717,7 +724,9 @@ function! s:source_win_enter() abort
 endfunction
 
 function! s:minimap_buffer_enter_handler() abort
-    " do nothing
+    " Move the cursor to where we were in the main buffer. Without this it
+    " jumps to the top of the minimap
+    call cursor(s:last_pos, 1)
 endfunction
 
 function! s:source_buffer_enter_handler() abort


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

fixes #133 

Entering the minimap would cause the cursor to jump to the top of the buffer, breaking expected workflow benefits. Added a manual `cursor()` call when entering the minimap which should fix the issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.6.0
    - [ ] Vim: <Version>
