### PR TITLE
GH-135 - Fix warning when searching with `*` before minimap is opened

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -8,6 +8,7 @@ let s:STATE_DIFF_MOD     = 0b01000
 let s:STATE_WINDOW_RANGE = 0b10000
 let s:last_pos = {}
 let s:last_range = {}
+let s:win_info = {}
 
 function! minimap#vim#MinimapToggle() abort
     call s:toggle_window()
@@ -843,7 +844,7 @@ function! minimap#vim#UpdateColorSearch(query) abort
 endfunction
 
 function! s:minimap_update_color_search(query) abort
-    if win_getid() != s:win_info['mmwinid']
+    if s:win_info != {} && win_getid() != s:win_info['mmwinid']
         call s:minimap_color_search(s:win_info, a:query)
     endif
 endfunction


### PR DESCRIPTION

<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [ ] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

Search was throwing an error if the minimap hadn't been opened yet.  Add guard on s:win_info being filled - stops search if minimap isn't open.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.6
    - [ ] Vim: <Version>
