### PR TITLE
fix: search_tests now uses writefile() function and platform-agnostic temp folder

### DIFF
--- a/t/search_tests.vim
+++ b/t/search_tests.vim
@@ -4,31 +4,36 @@
 
 " Define the minimap dimensions
 let s:win_info = { 'winid': 0, 'height': 12, 'mm_height': 3,
-                \ 'working_width': 91, 'mm_max_width': 9}
+                \ 'working_width': 91, 'mm_max_width': 9, 'max_width': 91}
 " Save the current view for restoring
 let s:testview = winsaveview()
 let s:testfile = expand('%')
 
+if has('win32')
+    let s:tempfolder = fnamemodify(expand("$TEMP"), ":p:h")
+else
+    let s:tempfolder = '/tmp'
+endif
+
 " Search tests
 function! s:minimap_test_search()
     " Create the subjest of our search
-    let test_file = '/tmp/minimap_search_unit_test_file'
-    let text =        'This is a test line and it needs to be long enough to register as multiple braille characters.\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'pad height\n'
-    let text = text . 'And another, this one is shorter\n'
-    let text = text . 'and flows to the numbers line, this one, this one has some numbers 1234 numbers'
-    execute 'silent !echo "' . text . '" > ' . test_file
+    let test_file = s:tempfolder . '/minimap_search_unit_test_file'
+    let text = ["This is a test line and it needs to be long enough to register as multiple braille characters." 
+             \ ,"pad height" 
+             \ ,"pad height" 
+             \ ,"pad height" 
+             \ ,"pad height" 
+             \ ,"pad height" 
+             \ ,"pad height" 
+             \ ,"pad height" 
+             \ ,"pad height" 
+             \ ,"pad height" 
+             \ ,"And another, this one is shorter" 
+             \ ,"and flows to the numbers line, this one, this one has some numbers 1234 numbers"]
+    call writefile(text, test_file)
     execute 'edit ' . test_file
 endfunction
-
 function! s:minimap_test_search_beginning_of_file()
     " Beginning of file
     let search = '\cThi'
@@ -118,3 +123,4 @@ call testify#it('Search - Many results',         function('s:minimap_test_search
 call testify#it('Search - Long Match',           function('s:minimap_test_search_long_match'))
 call testify#it('Search - History',              function('s:minimap_test_search_history'))
 call testify#it('Search tear down', function('s:minimap_test_search_tear_down'))
+

--- a/t/search_tests.vim
+++ b/t/search_tests.vim
@@ -10,7 +10,7 @@ let s:testview = winsaveview()
 let s:testfile = expand('%')
 
 if has('win32')
-    let s:tempfolder = fnamemodify(expand("$TEMP"), ":p:h")
+    let s:tempfolder = fnamemodify(expand('$TEMP'), ':p:h')
 else
     let s:tempfolder = '/tmp'
 endif
@@ -123,4 +123,3 @@ call testify#it('Search - Many results',         function('s:minimap_test_search
 call testify#it('Search - Long Match',           function('s:minimap_test_search_long_match'))
 call testify#it('Search - History',              function('s:minimap_test_search_history'))
 call testify#it('Search tear down', function('s:minimap_test_search_tear_down'))
-

--- a/t/search_tests.vim
+++ b/t/search_tests.vim
@@ -19,18 +19,18 @@ endif
 function! s:minimap_test_search()
     " Create the subjest of our search
     let test_file = s:tempfolder . '/minimap_search_unit_test_file'
-    let text = ["This is a test line and it needs to be long enough to register as multiple braille characters." 
-             \ ,"pad height" 
-             \ ,"pad height" 
-             \ ,"pad height" 
-             \ ,"pad height" 
-             \ ,"pad height" 
-             \ ,"pad height" 
-             \ ,"pad height" 
-             \ ,"pad height" 
-             \ ,"pad height" 
-             \ ,"And another, this one is shorter" 
-             \ ,"and flows to the numbers line, this one, this one has some numbers 1234 numbers"]
+    let text = [ 'This is a test line and it needs to be long enough to register as multiple braille characters.'
+             \ , 'pad height'
+             \ , 'pad height'
+             \ , 'pad height'
+             \ , 'pad height'
+             \ , 'pad height'
+             \ , 'pad height'
+             \ , 'pad height'
+             \ , 'pad height'
+             \ , 'pad height'
+             \ , 'And another, this one is shorter'
+             \ , 'and flows to the numbers line, this one, this one has some numbers 1234 numbers']
     call writefile(text, test_file)
     execute 'edit ' . test_file
 endfunction


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

Fixes #129, partially.

I also ran the tests on my Linux installation, and they had the same problems.  

First error: there is no 'max_width' key present in the dictionary.  This error was extremely puzzling, given that the code betrays no possible way such an error could occur.  So, I added the `max_width` key in, manually, to the value of `working_width`, and it just seems to work.  Needs to be investigated more to actually solve the problem.  Error output pictured below:

```viml
√ Search setup
✗ Search - Beginning of file
	Vim(let):E716: Key not present in Dictionary: "max_width"
		<SNR>81_minimap_test_search_beginning_of_file:4
✗ Search - Beginning of line
	Vim(let):E716: Key not present in Dictionary: "max_width"
		<SNR>81_minimap_test_search_beginning_of_line:6
...
```

Second: after making that change, I inspected the file that was actually being written to, and found that Vimscript was not actually putting in newlines where they should be.  Instead the buffer was all written on one line, displaying `\n` directly as a string rather than as a newline.  I changed the script to instead use `writefile()`, which automatically puts newlines in between its string arguments.  It seems to work.  Old output buffer:

```
This is a test line and it needs to be long enough to register as multiple braille characters.\npad height\npad height\npad height\npad height\npad height\npad height\npad height\npad height\npad height\nAnd another, this one is shorter\nand flows to the numbers line, this one, this one has some numbers 1234 numbers
```

Third: Windows was not able to create the folder `/tmp/minimap...` on my machine, so I added a check for the OS type to ensure that Unix users could use `/tmp` and Windows users would default to the `%TEMP%` environment variable.  Error output:

```viml
Vim(call):E482: Can't open file /tmp/minimap_search_unit_test_file for writing: no such file or directory
```

In total, these got the tests to work on my Windows and Linux machines alike.

```viml
√ Search setup
√ Search - Beginning of file
√ Search - Beginning of line
√ Search - End of line
√ Search - Multi match per line
√ Search - Spanning a line
√ Search - Many results
√ Search - Long Match
√ Search - History
√ Search tear down
* Test Summary
* ------------
* All tests successful
* Tests=10
* Result: PASS
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.5.0
    - [ ] Vim: <Version>
