### PR TITLE
Fix buffer switching lag by caching the largest line value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ let g:minimap_auto_start_win_enter = 1
 
 ### 🛠  Commands
 
-| Flag                   | Description                    |
-|------------------------|--------------------------------|
-| Minimap                | Show minimap window            |
-| MinimapClose           | Close minimap window           |
-| MinimapToggle          | Toggle minimap window          |
-| MinimapRefresh         | Force refresh minimap window   |
-| MinimapUpdateHighlight | Force update minimap highlight |
+| Flag                   | Description                                  |
+|------------------------|----------------------------------------------|
+| Minimap                | Show minimap window                          |
+| MinimapClose           | Close minimap window                         |
+| MinimapToggle          | Toggle minimap window                        |
+| MinimapRefresh         | Force refresh minimap window                 |
+| MinimapUpdateHighlight | Force update minimap highlight               |
+| MinimapRescan          | Force recalculation of minimap scaling ratio |
 
 ### ⚙  Options
 

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -32,6 +32,13 @@ function! minimap#vim#MinimapUpdateHighlight() abort
     call s:update_highlight()
 endfunction
 
+function! minimap#vim#MinimapRescan() abort
+    call remove(s:len_cache, expand('%'))
+    let s:win_info = s:get_window_info()
+    call s:refresh_minimap(1)
+    call s:update_highlight()
+endfunction
+
 function! s:buffer_enter_handler() abort
     if &filetype ==# 'minimap'
         call s:minimap_buffer_enter_handler()

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -9,6 +9,7 @@ let s:STATE_WINDOW_RANGE = 0b10000
 let s:last_pos = {}
 let s:last_range = {}
 let s:win_info = {}
+let s:len_cache = {}
 
 function! minimap#vim#MinimapToggle() abort
     call s:toggle_window()
@@ -496,15 +497,22 @@ function! s:get_window_info() abort
         let mmwinid = win_getid(mmwinnr)
         let height = line('$')
         let max_width = 0
-        " Get the max width of this buffer
-        let line_num = 1
-        while line_num <= line('$')
-            call setpos('.', [0, line_num, 1])
-            " Move cursor to the last non-blank character on the line
-            normal! g_
-            let max_width = max([max_width, col('.')])
-            let line_num = line_num + 1
-        endwhile
+        " Get the max width of this buffer. Value is cached so this only runs
+        " on first open of any file.
+        let filename = expand('%')
+        if has_key(s:len_cache, filename)
+            let max_width = s:len_cache[filename]
+        else
+            let line_num = 1
+            while line_num <= line('$')
+                call setpos('.', [0, line_num, 1])
+                " Move cursor to the last non-blank character on the line
+                normal! g_
+                let max_width = max([max_width, col('.')])
+                let line_num = line_num + 1
+            endwhile
+            let s:len_cache[filename] = max_width
+        endif
         " Let users override the max width. By default, this does nothing.
         let working_width = min([max_width, g:minimap_window_width_override_for_scaling])
         " Protect against divide by 0 or negative hscale - working_width must be > 0

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -31,6 +31,12 @@ MinimapUpdateHighlight                                 *MinimapUpdateHighlight*
 
   Force update minimap window
 
+MinimapRescan                                                   *MinimapRescan*
+
+  Force recalculation of minimap scaling ratio.
+  Scans every line of the buffer to calculate the scaling ratio, then updates
+  the minimap. Scanning can cause noticeable lag on large files.
+
 =============================================================================
 2. Options                                                    *minimap-options*
 

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -21,6 +21,7 @@ command! MinimapClose           call minimap#vim#MinimapClose()
 command! MinimapToggle          call minimap#vim#MinimapToggle()
 command! MinimapRefresh         call minimap#vim#MinimapRefresh()
 command! MinimapUpdateHighlight call minimap#vim#MinimapUpdateHighlight()
+command! MinimapRescan          call minimap#vim#MinimapRescan()
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 """ Configuration


### PR DESCRIPTION
## Description
This prevents a rescan and trades time for theoretical accuracy. It's
possible a long line is added (or taken away) after we open the file,
and we won't handle that as well - scaling won't be as nice and search
highlights won't be accurate. The simple fix if that ever becomes the
case is to close and reopen the file, so I believe this tradeoff is
worth it. The file will have undergone significant changes to enter this
corner case.

<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: <Version>
    - [ ] Vim: <Version>
