### PR TITLE
Add g:minimap_set_highlights to disable ColorScheme autocmd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ let g:minimap_auto_start_win_enter = 1
 | `g:minimap_highlight_range`                   | `0`                                                       | if set, minimap will highlight range of visible lines                |
 | `g:minimap_highlight_search`                  | `0`                                                       | if set, minimap will highlight searched patterns                     |
 | `g:minimap_git_colors`                        | `0`                                                       | if set, minimap will highlight range of changes as reported by git   |
+| `g:minimap_set_highlights`                    | `1`                                                       | if set, minimap will create an autocommand to set highlights on color scheme changes. |
+
 
 ### ⚙  Color Options
 Minimap.vim sets its own color groups to give a reasonable default.
@@ -112,27 +114,33 @@ Minimap.vim sets its own color groups to give a reasonable default.
 | `g:minimap_range_diff_color`        | `minimapRangeDiffLine`                                    | the color group for the window range encompassing modified lines     |
 
 You can create your own colorgroup by specifying the foreground and background colors for the cterm or gui:
+
 ```
 :highlight minimapCursor ctermbg=59  ctermfg=228 guibg=#5F5F5F guifg=#FFFF87
 ```
 
 For more information, see `:help highlight`
 
-note: some colorschemes will clear all previous colors, so you may have to add an `autocmd` to ensure your custom colorgroups are added back:
+Note: some colorschemes will clear all previous colors, so you may have to add an `autocmd` to ensure your custom colorgroups are added back:
+
 ```
 autocmd ColorScheme *
         \ highlight minimapCursor            ctermbg=59  ctermfg=228 guibg=#5F5F5F guifg=#FFFF87 |
         \ highlight minimapRange             ctermbg=242 ctermfg=228 guibg=#4F4F4F guifg=#FFFF87
 ```
 
+If you prefer to disable this behavior, set `g:minimap_set_highlights` to 0 / false. This is useful if you have a color scheme that sets the minimap highlight groups explicitly.
+
 ### 💬 F.A.Q
 
 ---
+
 #### Highlight and scroll are not working properly.
 
 Check the vim version you are using. `minimap.vim` requires [vim 8.2+](https://github.com/wfxr/minimap.vim/issues/5) or [neovim 0.5.0+](https://github.com/wfxr/minimap.vim/issues/4).
 
 ---
+
 #### Integrated with diagnostics or git status plugins?
 
 Not implemented currently but it should be possible.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ let g:minimap_auto_start_win_enter = 1
 | `g:minimap_highlight_range`                   | `0`                                                       | if set, minimap will highlight range of visible lines                |
 | `g:minimap_highlight_search`                  | `0`                                                       | if set, minimap will highlight searched patterns                     |
 | `g:minimap_git_colors`                        | `0`                                                       | if set, minimap will highlight range of changes as reported by git   |
-| `g:minimap_set_highlights`                    | `1`                                                       | if set, minimap will create an autocommand to set highlights on color scheme changes. |
+| `g:minimap_enable_highlight_colorgroup`                    | `1`                                                       | if set, minimap will create an autocommand to set highlights on color scheme changes. |
 
 
 ### ⚙  Color Options
@@ -129,7 +129,7 @@ autocmd ColorScheme *
         \ highlight minimapRange             ctermbg=242 ctermfg=228 guibg=#4F4F4F guifg=#FFFF87
 ```
 
-If you prefer to disable this behavior, set `g:minimap_set_highlights` to 0 / false. This is useful if you have a color scheme that sets the minimap highlight groups explicitly.
+If you prefer to disable this behavior, set `g:minimap_enable_highlight_colorgroup` to 0 / false. This is useful if you have a color scheme that sets the minimap highlight groups explicitly.
 
 ### 💬 F.A.Q
 

--- a/doc/minimap-vim.txt
+++ b/doc/minimap-vim.txt
@@ -151,6 +151,13 @@ g:minimap_git_colors                                     *g:minimap_git_colors*
   and `g:minimap_diff_color` are used for additions, deletions, and line changes
   respectively.
 
+`g:minimap_enable_highlight_colorgroup`
+
+  Type: |Number|
+  Default: 1
+
+  If set to 1, minimap will create anautocommand to set highlights on color scheme changes.
+
 g:minimap_base_highlight                             *g:minimap_base_highlight*
 
   Type: |String|

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -103,21 +103,23 @@ highlight minimapRangeDiffLine     ctermbg=242 ctermfg=141 guibg=#4F4F4F guifg=#
 " Need the autocmd because some colorschemes clear all colors, so we need to
 " re-add them so they stay valid
 
-augroup MinimapColorSchemes
-    autocmd!
-    autocmd ColorScheme *
-        \ highlight minimapCursor            ctermbg=59  ctermfg=228 guibg=#5F5F5F guifg=#FFFF87 |
-        \ highlight minimapRange             ctermbg=242 ctermfg=228 guibg=#4F4F4F guifg=#FFFF87 |
-        \ highlight minimapDiffRemoved                   ctermfg=197               guifg=#FC1A70 |
-        \ highlight minimapDiffAdded                     ctermfg=148               guifg=#A4E400 |
-        \ highlight minimapDiffLine                      ctermfg=141               guifg=#AF87FF |
-        \ highlight minimapCursorDiffRemoved ctermbg=59  ctermfg=197 guibg=#5F5F5F guifg=#FC1A70 |
-        \ highlight minimapCursorDiffAdded   ctermbg=59  ctermfg=148 guibg=#5F5F5F guifg=#A4E400 |
-        \ highlight minimapCursorDiffLine    ctermbg=59  ctermfg=141 guibg=#5F5F5F guifg=#AF87FF |
-        \ highlight minimapRangeDiffRemoved  ctermbg=242 ctermfg=197 guibg=#4F4F4F guifg=#FC1A70 |
-        \ highlight minimapRangeDiffAdded    ctermbg=242 ctermfg=148 guibg=#4F4F4F guifg=#A4E400 |
-        \ highlight minimapRangeDiffLine     ctermbg=242 ctermfg=141 guibg=#4F4F4F guifg=#AF87FF
-augroup END
+if !exists('g:minimap_set_highlights')
+    augroup MinimapColorSchemes
+        autocmd!
+        autocmd ColorScheme *
+            \ highlight minimapCursor            ctermbg=59  ctermfg=228 guibg=#5F5F5F guifg=#FFFF87 |
+            \ highlight minimapRange             ctermbg=242 ctermfg=228 guibg=#4F4F4F guifg=#FFFF87 |
+            \ highlight minimapDiffRemoved                   ctermfg=197               guifg=#FC1A70 |
+            \ highlight minimapDiffAdded                     ctermfg=148               guifg=#A4E400 |
+            \ highlight minimapDiffLine                      ctermfg=141               guifg=#AF87FF |
+            \ highlight minimapCursorDiffRemoved ctermbg=59  ctermfg=197 guibg=#5F5F5F guifg=#FC1A70 |
+            \ highlight minimapCursorDiffAdded   ctermbg=59  ctermfg=148 guibg=#5F5F5F guifg=#A4E400 |
+            \ highlight minimapCursorDiffLine    ctermbg=59  ctermfg=141 guibg=#5F5F5F guifg=#AF87FF |
+            \ highlight minimapRangeDiffRemoved  ctermbg=242 ctermfg=197 guibg=#4F4F4F guifg=#FC1A70 |
+            \ highlight minimapRangeDiffAdded    ctermbg=242 ctermfg=148 guibg=#4F4F4F guifg=#A4E400 |
+            \ highlight minimapRangeDiffLine     ctermbg=242 ctermfg=141 guibg=#4F4F4F guifg=#AF87FF
+    augroup END
+endif
 
 if !exists('g:minimap_base_highlight')
     let g:minimap_base_highlight = 'Normal'

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -82,7 +82,7 @@ if !exists('g:minimap_git_colors')
 endif
 
 if !exists('g:minimap_enable_highlight_colorgroup')
-    let g:minimap_git_colors = 1
+    let g:minimap_enable_highlight_colorgroup = 1
 endif
 
 if !exists('g:minimap_highlight_search')

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -81,6 +81,10 @@ if !exists('g:minimap_git_colors')
     let g:minimap_git_colors = 0
 endif
 
+if !exists('g:minimap_enable_highlight_colorgroup')
+    let g:minimap_git_colors = 1
+endif
+
 if !exists('g:minimap_highlight_search')
     let g:minimap_highlight_search = 0
 endif
@@ -103,7 +107,7 @@ highlight minimapRangeDiffLine     ctermbg=242 ctermfg=141 guibg=#4F4F4F guifg=#
 " Need the autocmd because some colorschemes clear all colors, so we need to
 " re-add them so they stay valid
 
-if !exists('g:minimap_set_highlights')
+if !exists('g:minimap_enable_highlight_colorgroup')
     augroup MinimapColorSchemes
         autocmd!
         autocmd ColorScheme *


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [X] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [X] I have searched through the existing issues or pull requests
- [X] I have verified all existing unit tests pass (See the README on how to run)
- [] I have added new tests if appropriate
- [X] I have performed a self-review of my code and commented hard-to-understand areas
- [X] I have made corresponding changes to the documentation (when necessary)

## Description

See issue #151 

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [X] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [X] Neovim: <Version>
    - [ ] Vim: <Version>
