### PR TITLE
diffoff in minimap window

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -191,12 +191,12 @@ function! s:open_window() abort
                 autocmd FocusGained,CursorMoved,CursorMovedI *  call s:handle_autocmd(5)
             endif
         endif
-        autocmd FocusGained,CursorMoved,CursorMovedI *      call s:handle_autocmd(6)
+        autocmd FocusGained,CursorMoved,CursorMovedI *          call s:handle_autocmd(6)
         if g:minimap_highlight_search != 0
             autocmd CmdlineLeave * if expand('<afile>') == '/' || expand('<afile>') == '?' |
                         \ call s:minimap_update_color_search(getcmdline())
         endif
-        autocmd DiffUpdated *                                   call s:handle_autocmd(7)
+        autocmd VimEnter,DiffUpdated *                          call s:handle_autocmd(7)
     augroup END
 
     " https://github.com/neovim/neovim/issues/6211
@@ -256,8 +256,8 @@ function! s:handle_autocmd(cmd) abort
         elseif a:cmd == 6           " FocusGained,CursorMoved,CursorMovedI *
             " echom 'FocusGained,CursorMoved,CursorMovedI *'
             call s:source_move()
-        elseif a:cmd == 7           " DiffUpdated *
-            " echom 'DiffUpdated *'
+        elseif a:cmd == 7           " VimEnter,DiffUpdated *
+            " echom 'VimEnter,DiffUpdated *'
             call s:minimap_diffoff()
         endif
     endif

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -196,6 +196,7 @@ function! s:open_window() abort
             autocmd CmdlineLeave * if expand('<afile>') == '/' || expand('<afile>') == '?' |
                         \ call s:minimap_update_color_search(getcmdline())
         endif
+        autocmd DiffUpdated *                                   call s:handle_autocmd(7)
     augroup END
 
     " https://github.com/neovim/neovim/issues/6211
@@ -255,6 +256,9 @@ function! s:handle_autocmd(cmd) abort
         elseif a:cmd == 6           " FocusGained,CursorMoved,CursorMovedI *
             " echom 'FocusGained,CursorMoved,CursorMovedI *'
             call s:source_move()
+        elseif a:cmd == 7           " DiffUpdated *
+            " echom 'DiffUpdated *'
+            call s:minimap_diffoff()
         endif
     endif
 endfunction
@@ -750,6 +754,15 @@ function! s:source_buffer_enter_handler() abort
     silent! call clearmatches(s:win_info['mmwinid'])
     call s:refresh_minimap(0)
     call s:update_highlight('source_buffer_enter_handler')
+endfunction
+
+function! s:minimap_diffoff() abort
+    let s:win_info = s:get_window_info()
+    if s:win_info == {}
+        return
+    endif
+    let mmwinid = s:win_info['mmwinid']
+    silent! call win_execute(mmwinid, 'diffoff')
 endfunction
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [ ] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (when necessary)

## Description

Fixes #150. `nvim -d a.txt b.txt` will cause the minimap window to be diffed. To prevent this, add an `DiffUpdated` autocmd and run `diffoff` in the minimap window.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [x] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [ ] Neovim: 0.8.0
    - [ ] Vim: <Version>
