### PR TITLE
open_window() should return if filetype is ignored

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -135,7 +135,7 @@ endfunction
 function! s:open_window() abort
     " If the minimap window is already open jump to it
     let mmwinnr = bufwinnr('-MINIMAP-')
-    if mmwinnr != -1 || s:closed_on()   " Don't open if file/buftype is closed on
+    if mmwinnr != -1 || s:closed_on() || s:ignored() " Don't open if file/buftype is ignored/closed on
         return
     endif
 


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [ ] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (when necessary)

## Description

Ignored (blocked) filetypes shouldn't open/close the minimap window

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [ ] Neovim: <Version>
    - [ ] Vim: <Version>
