### PR TITLE
Set bufhidden=wipe

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -152,7 +152,7 @@ function! s:open_window() abort
     setlocal filetype=minimap
     setlocal noreadonly " in case the "view" mode is used
     setlocal buftype=nofile
-    setlocal bufhidden=hide
+    setlocal bufhidden=wipe
     setlocal noswapfile
     setlocal nobuflisted
     setlocal nomodifiable


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [ ] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (when necessary)

## Description

If the minimap window becomes closed then the minimap buffer should be unloaded. I've noticed an issue with nvim-tree where running `bufwinnr('-MINIMAP-')` returns -1 in the nvim-tree window because during startup minimap leaves an invalid buffer. As a result, minimap can create multiple windows because it doesn't detect that there is an existing minimap window. A simple fix for this is to just wipe the minimap buffer when its hidden.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [x] Linux
    - [x] Mac OS X
    - [x] Windows
    - [ ] Others:
- Vim
    - [x] Neovim: 0.8.0
    - [ ] Vim: <Version>
