### PR TITLE
Fix background processing locking up with empty filename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
         shell: bash
       - name: Run Unit Tests
         run: |
-          nvim -c "set rtp+=$NEOVIM_CONFIG_PATH/plugins/vim-testify" -c "set rtp+=./" -S $NEOVIM_CONFIG_PATH/plugins/vim-testify/plugin/testify.vim -S ./plugin/minimap.vim +TestifySuite
+          echo "not empty file" > testfile
+          nvim -c "set rtp+=$NEOVIM_CONFIG_PATH/plugins/vim-testify" -c "set rtp+=./" -S $NEOVIM_CONFIG_PATH/plugins/vim-testify/plugin/testify.vim -S ./plugin/minimap.vim +TestifySuite testfile
         shell: bash
         env:
           NEOVIM_CONFIG_PATH: '${{ matrix.NEOVIM_CONFIG_PATH }}'

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -567,6 +567,14 @@ function! s:get_window_info() abort
             let g:minimap_getting_window_info = 0
             return {}
         endif
+
+        let filename = expand('%')
+        " echom 'checking filename [' . filename .']'
+        if filename == ''
+            let g:minimap_getting_window_info = 0
+            return {}
+        endif
+
         let curwinview = winsaveview()
 
         let mmwinid = win_getid(mmwinnr)
@@ -577,8 +585,6 @@ function! s:get_window_info() abort
         " file may result in an inaccurate minimap, but the tradeoff is worth
         " it. This cache only lasts for the life of this vim instance, so it
         " will be updated with each new open.
-        let filename = expand('%')
-        " echom 'checking filename ' . filename
         if has_key(s:len_cache, filename)
             let max_width = s:len_cache[filename]
         elseif g:minimap_background_processing == 0

--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -654,7 +654,7 @@ endfunction
 " This function builds a new line state table from scratch, clearing out the
 " old one.
 function! s:update_highlight(...) abort
-    if len(s:win_info) == 0
+    if s:win_info == {}
         return
     endif
 

--- a/t/utility_tests.vim
+++ b/t/utility_tests.vim
@@ -28,5 +28,5 @@ endfunction
 
 call testify#it('Minimap conversion math works as expected',
             \ function('s:minimap_test_utility'))
-call testify#it('Opening minimap restults in only one call to update_minimap',
+call testify#it('Opening minimap results in only one call to update_minimap',
             \ function('s:minimap_test_calls_to_update_minimap'))


### PR DESCRIPTION
An empty filename would cause the hold on `g:minimap_getting_window_info` to never be dropped, locking out the window info function. 

This change checks for an empty filename early, exiting + dropping the mutex if the filename is empty.