### PR TITLE
README - brew package for gnu wc is coreutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ nnoremap <silent> `` :nohlsearch<CR>:call minimap#vim#ClearColorSearch()<CR>
 The version of `wc` that ships with MacOS does not have support for the `-L` flag.
 To use background processing on MacOS, install `gnu-wc`. Example via homebrew:
 ```
-brew install gnu-wc
+brew install coreutils
 ```
 
 ---


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [ ] I have verified all existing unit tests pass (See the README on how to run)
- [ ] I have added new tests if appropriate
- [ ] I have performed a self-review of my code and commented hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (when necessary)

## Description

The `brew install` command listed to acquire gnu wc on macOS is incorrect. There is no `gnu-wc` package; GNU wc is provided by the `coreutils` package.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [ ] Neovim: <Version>
    - [ ] Vim: <Version>
