### PR TITLE
Fix E474 error in minimap_buffer_enter_handler when opening minimap buffer without a file

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -853,6 +853,9 @@ function! s:source_win_enter() abort
 endfunction
 
 function! s:minimap_buffer_enter_handler() abort
+    if empty(s:last_pos) || s:last_pos <= 0
+        return
+    endif
     " Move the cursor to where we were in the main buffer. Without this it
     " jumps to the top of the minimap
     call cursor(s:last_pos, 1)


### PR DESCRIPTION

<!-- Check all that apply [x] -->

## Check list

- [x] I have read through the [README](https://github.com/wfxr/minimap.vim/blob/master/README.md) (especially F.A.Q section)
- [x] I have searched through the existing issues or pull requests
- [x] I have verified all existing unit tests pass (See the README on how to run)
- [x] I have added new tests if appropriate
- [x] I have performed a self-review of my code and commented hard-to-understand areas
- [x] I have made corresponding changes to the documentation (when necessary)

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

This commit addresses an issue where the minimap plugin would throw an "E474: Invalid argument" error when Vim is opened without a file and the minimap buffer is focused. The error was caused by attempting to move the cursor to an invalid position.

The fix adds a condition to `s:minimap_buffer_enter_handler()` to ensure `s:last_pos` is not empty or less than or equal to zero before calling `cursor()`.

This resolves the issue by preventing the cursor from moving to an invalid position.

Issue: https://github.com/wfxr/minimap.vim/issues/199

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement of existing features
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [ ] CI / CD

## Test environment

- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
- Vim
    - [ ] Neovim: <Version>
    - [x] Vim: 9.1
